### PR TITLE
 Import ABC from collections.abc instead of collections for Python 3.9 compatibility.

### DIFF
--- a/pingouin/external/tabulate.py
+++ b/pingouin/external/tabulate.py
@@ -407,7 +407,7 @@ _multiline_codes_bytes = re.compile(b"\r|\n|\r\n")
 # ANSI color codes
 _invisible_codes = re.compile(r"\x1b\[\d+[;\d]*m|\x1b\[\d*\;\d*\;\d*m")
 # ANSI color codes
-_invisible_codes_bytes = re.compile(b"\x1b\[\d+[;\d]*m|\x1b\[\d*\;\d*\;\d*m")
+_invisible_codes_bytes = re.compile(b"\x1b\\[\\d+\\[;\\d]*m|\x1b\\[\\d*;\\d*;\\d*m")
 
 
 def simple_separated_format(separator):

--- a/pingouin/plotting.py
+++ b/pingouin/plotting.py
@@ -1111,7 +1111,7 @@ def plot_circmean(alpha, figsize=(4, 4), dpi=None, ax=None,
     ax.spines['left'].set_visible(False)
     ax.spines['bottom'].set_visible(False)
     ax.text(1.2, 0, '0', verticalalignment='center')
-    ax.text(-1.3, 0, '$\pi$', verticalalignment='center')
-    ax.text(0, 1.2, '$+\pi/2$', horizontalalignment='center')
-    ax.text(0, -1.3, '$-\pi/2$', horizontalalignment='center')
+    ax.text(-1.3, 0, r'$\pi$', verticalalignment='center')
+    ax.text(0, 1.2, r'$+\pi/2$', horizontalalignment='center')
+    ax.text(0, -1.3, r'$-\pi/2$', horizontalalignment='center')
     return ax

--- a/pingouin/utils.py
+++ b/pingouin/utils.py
@@ -1,6 +1,6 @@
 # Author: Raphael Vallat <raphaelvallat9@gmail.com>
 # Date: April 2018
-import collections
+import collections.abc
 import numpy as np
 from pingouin.external.tabulate import tabulate
 import pandas as pd
@@ -302,7 +302,7 @@ def _flatten_list(x, include_tuple=False):
     # Remove None
     x = list(filter(None.__ne__, x))
     for el in x:
-        x_is_iter = isinstance(x, collections.Iterable)
+        x_is_iter = isinstance(x, collections.abc.Iterable)
         if x_is_iter:
             if not isinstance(el, (str, tuple)):
                 result.extend(_flatten_list(el))


### PR DESCRIPTION
*  Import ABC from collections.abc instead of collections for Python 3.9 compatibility.
* Fix deprecation warning due to invalid escape sequences.