### PR TITLE
ENH: plot_paired: update default kwargs instead of overwriting

### DIFF
--- a/pingouin/plotting.py
+++ b/pingouin/plotting.py
@@ -459,6 +459,12 @@ def plot_paired(data=None, dv=None, within=None, subject=None, order=None,
     """
     from pingouin.utils import _check_dataframe, remove_rm_na
 
+    # Update default kwargs with specified inputs
+    _pointplot_kwargs = {'scale': .6, 'markers': '.'}
+    _pointplot_kwargs.update(pointplot_kwargs)
+    _boxplot_kwargs = {'color': 'lightslategrey', 'width': .2}
+    _boxplot_kwargs.update(boxplot_kwargs)
+
     # Validate args
     _check_dataframe(data=data, dv=dv, within=within, subject=subject,
                      effects='within')
@@ -495,11 +501,11 @@ def plot_paired(data=None, dv=None, within=None, subject=None, order=None,
 
         # Plot individual lines using Seaborn
         sns.pointplot(data=tmp, x=within, y=dv, order=order, color=color,
-                      ax=ax, **pointplot_kwargs)
+                      ax=ax, **_pointplot_kwargs)
 
     if boxplot:
         sns.boxplot(data=data, x=within, y=dv, order=order, ax=ax,
-                    **boxplot_kwargs)
+                    **_boxplot_kwargs)
 
     # Despine and trim
     sns.despine(trim=True, ax=ax)


### PR DESCRIPTION
Instead of overwriting all default kwargs when setting a single element, the default kwargs are now updated, keeping the defaults if not otherwise specified.

In general, I'd say that specifying the defaults in the function definition kwargs could be avoided entirely, but this would require a more thorough refactoring.

If this implementation is ok, I could integrate it for all plotting functions.