### PR TITLE
ENH: plot_paired: boxplot_in_front argument added to allow setting the boxplot in the foreground

### DIFF
--- a/pingouin/plotting.py
+++ b/pingouin/plotting.py
@@ -378,7 +378,8 @@ def qqplot(x, dist='norm', sparams=(), confidence=.95, figsize=(5, 4),
 
 
 def plot_paired(data=None, dv=None, within=None, subject=None, order=None,
-                boxplot=True, figsize=(4, 4), dpi=100, ax=None,
+                boxplot=True, boxplot_in_front=False,
+                figsize=(4, 4), dpi=100, ax=None,
                 colors=['green', 'grey', 'indianred'],
                 pointplot_kwargs={'scale': .6, 'markers': '.'},
                 boxplot_kwargs={'color': 'lightslategrey', 'width': .2}):
@@ -465,6 +466,14 @@ def plot_paired(data=None, dv=None, within=None, subject=None, order=None,
     _boxplot_kwargs = {'color': 'lightslategrey', 'width': .2}
     _boxplot_kwargs.update(boxplot_kwargs)
 
+    # Set boxplot in front of Line2D plot (zorder=2 for both) and add alpha
+    if boxplot_in_front:
+        _boxplot_kwargs.update({
+            'boxprops': {'zorder': 2},
+            'whiskerprops': {'zorder': 2},
+            'zorder': 2,
+        })
+
     # Validate args
     _check_dataframe(data=data, dv=dv, within=within, subject=subject,
                      effects='within')
@@ -506,6 +515,11 @@ def plot_paired(data=None, dv=None, within=None, subject=None, order=None,
     if boxplot:
         sns.boxplot(data=data, x=within, y=dv, order=order, ax=ax,
                     **_boxplot_kwargs)
+
+        # Set alpha to patch of boxplot but not to whiskers
+        for patch in ax.artists:
+            r, g, b, a = patch.get_facecolor()
+            patch.set_facecolor((r, g, b, .75))
 
     # Despine and trim
     sns.despine(trim=True, ax=ax)

--- a/pingouin/tests/test_plotting.py
+++ b/pingouin/tests/test_plotting.py
@@ -77,7 +77,7 @@ class TestPlotting(TestCase):
                     ax=ax2)
         plot_paired(data=df, dv='Scores', within='Time',
                     subject='Subject', order=['June', 'August'],
-                    boxplot_in_front=False, ax=ax2)
+                    boxplot_in_front=True, ax=ax2)
         plt.close('all')
 
     def test_plot_shift(self):

--- a/pingouin/tests/test_plotting.py
+++ b/pingouin/tests/test_plotting.py
@@ -75,6 +75,9 @@ class TestPlotting(TestCase):
         plot_paired(data=df, dv='Scores', within='Time',
                     subject='Subject', order=['June', 'August'],
                     ax=ax2)
+        plot_paired(data=df, dv='Scores', within='Time',
+                    subject='Subject', order=['June', 'August'],
+                    boxplot_in_front=False, ax=ax2)
         plt.close('all')
 
     def test_plot_shift(self):


### PR DESCRIPTION
Added the argument `boxplot_in_front` (default=False to retain standard behavior) to `plot_paired`.
This allows setting the boxplot above the line plots, f.i. for large numbers of subjects. Also added a slight `alpha=.75` to the boxplot patch (but not to the borders) to see the lines below the boxplot.

Example:
```
import numpy as np
import pandas as pd
import dev_pg.pingouin.pingouin as pg

df = pd.DataFrame(
    {'id': np.tile(np.arange(100), 2),
     'dv': np.random.rand(200),
     'wthn': np.concatenate((np.full(100, 'A'), np.full(100, 'B')))})

# default plot
pg.plot_paired(df, dv='dv', within='wthn', subject='id')
# boxplot in front with alpha=.75
pg.plot_paired(df, dv='dv', within='wthn', subject='id', boxplot_in_front=True)
```