### PR TITLE
Implement BF formatting using the new options module

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -33,6 +33,7 @@ d. Added ``boxplot_in_front`` argument to the :py:func:`pingouin.plot_paired`. W
 e. Better handling of Categorical columns in several functions (e.g. ANOVA). See `issue 122 <https://github.com/raphaelvallat/pingouin/issues/122>`_.
 f. :py:func:`multivariate_normality` now also returns the test statistic. This function also comes with better unit testing against the MVN R package.
 g. :py:func:`pingouin.pairwise_corr` can now control for all covariates by excluding each specific set of column-combinations from the covariates to use for this combination, similar to :py:func:`pingouin.pcorr`. See `PR 124 <https://github.com/raphaelvallat/pingouin/pull/124>`_.
+h. Bayes factor formatting is now handled via the options module. The default behaviour is unchanged (return as formatted string), but can easily be disabled by setting `pingouin.options["round.column.BF10"] = None`. See `PR 126 <https://github.com/raphaelvallat/pingouin/pull/126>`_.
 
 v0.3.7 (July 2020)
 ------------------

--- a/pingouin/bayesian.py
+++ b/pingouin/bayesian.py
@@ -10,6 +10,8 @@ __all__ = ["bayesfactor_ttest", "bayesfactor_pearson", "bayesfactor_binom"]
 def _format_bf(bf, precision=3, trim='0'):
     """Format BF10 to floating point or scientific notation.
     """
+    if type(bf) == str:
+        return bf
     if bf >= 1e4 or bf <= 1e-4:
         out = np.format_float_scientific(bf, precision=precision, trim=trim)
     else:

--- a/pingouin/bayesian.py
+++ b/pingouin/bayesian.py
@@ -50,7 +50,7 @@ def bayesfactor_ttest(t, nx, ny=None, paired=False, tail='two-sided', r=.707):
 
     Returns
     -------
-    bf : str
+    bf : float
         Scaled Jeffrey-Zellner-Siow (JZS) Bayes Factor (BF10).
         The Bayes Factor quantifies the evidence in favour of the
         alternative hypothesis.
@@ -129,7 +129,7 @@ def bayesfactor_ttest(t, nx, ny=None, paired=False, tail='two-sided', r=.707):
     # Check T-value
     assert isinstance(t, (int, float)), 'The T-value must be a int or a float.'
     if not np.isfinite(t):
-        return str(np.nan)
+        return np.nan
 
     # Function to be integrated
     def fun(g, t, n, r, df):
@@ -169,7 +169,7 @@ def bayesfactor_pearson(r, n, tail='two-sided', method='ly', kappa=1.):
         Pearson correlation coefficient.
     n : int
         Sample size.
-    tail : str
+    tail : float
         Tail of the alternative hypothesis. Can be *'two-sided'*,
         *'one-sided'*, *'greater'* or *'less'*. *'greater'* corresponds to a
         positive correlation, *'less'* to a negative correlation.
@@ -279,7 +279,7 @@ def bayesfactor_pearson(r, n, tail='two-sided', method='ly', kappa=1.):
 
     # Wrong input
     if not np.isfinite(r) or n < 2:
-        return str(np.nan)
+        return np.nan
     assert -1 <= r <= 1, 'r must be between -1 and 1.'
 
     if tail.lower() != 'two-sided' and method.lower() == 'wetzels':

--- a/pingouin/bayesian.py
+++ b/pingouin/bayesian.py
@@ -156,7 +156,7 @@ def bayesfactor_ttest(t, nx, ny=None, paired=False, tail='two-sided', r=.707):
     if ((tail == 'greater' and t < 0) or (tail == 'less' and t > 0)) and bf10 > 1:  # noqa
         bf10 = 1 / bf10
 
-    return _format_bf(bf10)
+    return bf10
 
 
 def bayesfactor_pearson(r, n, tail='two-sided', method='ly', kappa=1.):
@@ -333,7 +333,7 @@ def bayesfactor_pearson(r, n, tail='two-sided', method='ly', kappa=1.):
                 # We expect the correlation to be negative
                 bf10 = bf10neg
 
-    return _format_bf(bf10)
+    return bf10
 
 
 def bayesfactor_binom(k, n, p=.5):
@@ -431,4 +431,4 @@ def bayesfactor_binom(k, n, p=.5):
         return binom.pmf(k, n, g)
 
     bf10 = quad(fun, 0, 1, args=(k, n))[0] / binom.pmf(k, n, p)
-    return _format_bf(bf10)
+    return bf10

--- a/pingouin/config.py
+++ b/pingouin/config.py
@@ -1,3 +1,5 @@
+from .bayesian import _format_bf
+
 """Pingouin global configuration."""
 
 __all__ = ['options', 'set_default_options']
@@ -19,3 +21,6 @@ def set_default_options():
     # Rounding behavior
     options['round'] = None
     options['round.column.CI95%'] = 2
+
+    # default is to return Bayes factors inside DataFrames as formatted str
+    options['round.column.BF10'] = _format_bf

--- a/pingouin/tests/test_bayesian.py
+++ b/pingouin/tests/test_bayesian.py
@@ -5,21 +5,25 @@ from pingouin.parametric import ttest
 from pingouin.bayesian import bayesfactor_ttest, bayesfactor_binom
 from pingouin.bayesian import bayesfactor_pearson as bfp
 
+from pytest import approx
+
 np.random.seed(1234)
 x = np.random.normal(size=100)
 y = np.random.normal(size=100)
 z = np.random.normal(loc=.5, size=100)
 v, w = np.random.multivariate_normal([0, 0], [[1, .8], [.8, 1]], 100).T
 
-
 class TestBayesian(TestCase):
     """Test bayesian.py."""
 
     def test_bayesfactor_ttest(self):
         """Test function bayesfactor_ttest."""
-        assert float(bayesfactor_ttest(3.5, 20, 20)) == 26.743
-        assert float(bayesfactor_ttest(3.5, 20)) == 17.185
-        assert float(bayesfactor_ttest(3.5, 20, 1)) == 17.185
+        # check for approximate equality with 1e-3 tolerance
+        # (as this is how we store the values here)
+        appr = lambda x: approx(x, abs=1e-3)
+        assert bayesfactor_ttest(3.5, 20, 20) == appr(26.743)
+        assert bayesfactor_ttest(3.5, 20) == appr(17.185)
+        assert bayesfactor_ttest(3.5, 20, 1) == appr(17.185)
         # Compare against BayesFactor::testBF
         # >>> ttestBF(df$x, df$y, paired = FALSE, rscale = "medium")
         assert ttest(x, y).at['T-test', 'BF10'] == '0.183'
@@ -27,49 +31,54 @@ class TestBayesian(TestCase):
         assert int(float(ttest(x, z).at['T-test', 'BF10'])) == 1290
         assert int(float(ttest(x, z, paired=True).at['T-test', 'BF10'])) == 420
         # Now check the alternative tails
-        assert float(bayesfactor_ttest(3.5, 20, 20, tail='greater')) > 1
-        assert float(bayesfactor_ttest(3.5, 20, 20, tail='less')) < 1
-        assert float(bayesfactor_ttest(-3.5, 20, 20, tail='greater')) < 1
-        assert float(bayesfactor_ttest(-3.5, 20, 20, tail='less')) > 1
+        assert bayesfactor_ttest(3.5, 20, 20, tail='greater') > 1
+        assert bayesfactor_ttest(3.5, 20, 20, tail='less') < 1
+        assert bayesfactor_ttest(-3.5, 20, 20, tail='greater') < 1
+        assert bayesfactor_ttest(-3.5, 20, 20, tail='less') > 1
         # Check with wrong T-value
-        assert bayesfactor_ttest(np.nan, 20, paired=True) == 'nan'
+        assert np.isnan(bayesfactor_ttest(np.nan, 20, paired=True))
 
     def test_bayesfactor_pearson(self):
         """Test function bayesfactor_pearson."""
         # Compare the analytical solution to JASP / R (method='ly')
         # Similar to JASP with kappa=1, or correlationBF with rscale='wide'
-        assert float(bfp(0.1, 83)) == 0.204
-        assert float(bfp(-0.1, 83)) == 0.204
-        assert float(bfp(0.1, 83, tail='one-sided')) == 0.332
-        assert float(bfp(0.1, 83, tail='greater')) == 0.332
-        assert float(bfp(0.1, 83, tail='pos')) == 0.332
-        assert float(bfp(0.1, 83, tail='less')) == 0.076
-        assert float(bfp(0.1, 83, tail='neg')) == 0.076
-        assert float(bfp(-0.1, 83, tail='one-sided')) == 0.332
-        assert float(bfp(-0.1, 83, tail='pos')) == 0.076
+        # check for approximate equality with 1e-3 tolerance
+        # (as this is how we store the values here)
+        appr = lambda x: approx(x, abs=1e-3)
+        assert bfp(0.1, 83) == appr(0.204)
+        assert bfp(-0.1, 83) == appr(0.204)
+        assert bfp(0.1, 83, tail='one-sided') == appr(0.332)
+        assert bfp(0.1, 83, tail='greater') == appr(0.332)
+        assert bfp(0.1, 83, tail='pos') == appr(0.332)
+        assert bfp(0.1, 83, tail='less') == appr(0.076)
+        assert bfp(0.1, 83, tail='neg') == appr(0.076)
+        assert bfp(-0.1, 83, tail='one-sided') == appr(0.332)
+        assert bfp(-0.1, 83, tail='pos') == appr(0.076)
 
         # Example 2. Compare with JASP.
         r, _ = pearsonr(x, y)
         n = 100
-        assert float(bfp(r, n)) == 0.174
-        assert float(bfp(r, n, tail='g')) == 0.275
-        assert float(bfp(r, n, tail='g', method='wetzels')) == 0.275
-        assert float(bfp(r, n, tail='l')) == 0.073
+        assert bfp(r, n) == appr(0.174)
+        assert bfp(r, n, tail='g') == appr(0.275)
+        assert bfp(r, n, tail='g', method='wetzels') == appr(0.275)
+        assert bfp(r, n, tail='l') == appr(0.073)
         r, _ = pearsonr(v, w)
-        assert float(bfp(r, n)) == 2.321e+22
-        assert float(bfp(r, n, tail='g')) == 4.643e+22
-        # assert float(bfp(r, n, tail='l')) == 1.677e-26
+        appr = lambda x: approx(x, rel=1e-3) # relative tolerance here
+        assert bfp(r, n) == appr(2.321e+22)
+        assert bfp(r, n, tail='g') == appr(4.643e+22)
+        # assert bfp(r, n, tail='l')) == 1.677e-26
 
         # Compare the integral solving method (Wetzels)
-        assert float(bfp(0.6, 20, method='wetzels')) == 8.221
-        assert float(bfp(-0.6, 20, method='wetzels')) == 8.221
-        assert float(bfp(0.6, 10, method='wetzels')) == 1.278
+        appr = lambda x: approx(x, abs=1e-3) # back to absolute tolerance
+        assert bfp(0.6, 20, method='wetzels') == appr(8.221)
+        assert bfp(-0.6, 20, method='wetzels') == appr(8.221)
+        assert bfp(0.6, 10, method='wetzels') == appr(1.278)
 
         # Wrong input
-        assert bfp(np.nan, 20) == 'nan'
-        assert bfp(0.8, 1) == 'nan'
-        assert bfp(np.inf, 1) == 'nan'
-        assert bfp(-1, 100) == 'inf'
+        assert np.isnan(bfp(np.nan, 20))
+        assert np.isnan(bfp(0.8, 1))
+        assert np.isnan(bfp(np.inf, 1))
+        assert np.isinf(bfp(-1, 100))
 
     def test_bayesfactor_binom(self):
         """Test function bayesfactor_binom.
@@ -77,7 +86,7 @@ class TestBayesian(TestCase):
         See also docstring of the function for a comparison with Wikipedia.
         """
         def bf10(x):
-            return str(round(1 / float(x), 3))
+            return approx(1 / x, rel=1e-5)
         assert bayesfactor_binom(16, 20) == bf10(0.09703159)
         assert bayesfactor_binom(16, 20, 0.8) == bf10(4.582187)
         assert bayesfactor_binom(100, 1000, 0.1) == bf10(42.05881)

--- a/pingouin/utils.py
+++ b/pingouin/utils.py
@@ -114,7 +114,10 @@ def _postprocess_dataframe(df):
         if round_option is None:
             continue
         if callable(round_option):
-            df.at[row, col] = round_option(df.at[row, col])
+            newval = round_option(df.at[row, col])
+            # ensure that dtype changes are processed
+            df[col] = df[col].astype(type(newval))
+            df.at[row, col] = newval
             continue
         if isinstance(df.at[row, col], bool):
             # No rounding if value is a boolean


### PR DESCRIPTION
As discussed in #101.

The lower-level functions `bayesian.bayesfactor_ttest` etc. now return `float`s; all post-processing (i.e., formatting into scientific or positional string) is handled at the DataFrame level in `_postprocess_dataframe`.