### PR TITLE
multiple regression: catch rank deficient design matrices and warn

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -461,6 +461,7 @@ Note that this program is provided with NO WARRANTY OF ANY KIND. If you can, alw
 - `Arthur Paulino <https://github.com/arthurpaulino>`_
 - `Eelke Spaak <https://eelkespaak.nl/>`_
 - `Johannes Elfner <https://www.linkedin.com/in/johannes-elfner/>`_
+- `Stefan Appelhoff <https://stefanappelhoff.com>`_
 
 How to cite Pingouin?
 =====================

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ v0.3.9 (dev)
 **Enhancements**
 
 a. :py:func:`pingouin.plot_paired` now supports an arbitrary number of within-levels as well as horizontal plotting. See `PR 133 <https://github.com/raphaelvallat/pingouin/pull/133>`_.
+b. :py:func:`pingouin.linear_regression` now handles a rank deficient design matrix X by producing a warning and trying to calculate the sum of squared residuals without relying on :py:func:`np.linalg.lstsq`. See `issue 130 <https://github.com/raphaelvallat/pingouin/issues/130>`_.
 
 v0.3.8 (September 2020)
 -----------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -512,6 +512,7 @@ Note that this program is provided with NO WARRANTY OF ANY KIND. If you can, alw
 - `Arthur Paulino <https://github.com/arthurpaulino>`_
 - `Eelke Spaak <https://eelkespaak.nl/>`_
 - `Johannes Elfner <https://www.linkedin.com/in/johannes-elfner/>`_
+- `Stefan Appelhoff <https://stefanappelhoff.com>`_
 
 How to cite Pingouin?
 =====================

--- a/pingouin/regression.py
+++ b/pingouin/regression.py
@@ -406,7 +406,7 @@ def linear_regression(X, y, add_intercept=True, weights=None, coef_only=False,
     calc_ss_res = False
     if rank < Xw.shape[1]:
         warnings.warn('Design matrix supplied with `X` parameter is rank '
-                      f'deficient (rank {rank} with {Xw.shape[1]} columns. '
+                      f'deficient (rank {rank} with {Xw.shape[1]} columns). '
                       'That means that one or more of the columns in `X` '
                       'are a linear combination of one of more of the '
                       'other columns.')

--- a/pingouin/regression.py
+++ b/pingouin/regression.py
@@ -399,12 +399,14 @@ def linear_regression(X, y, add_intercept=True, weights=None, coef_only=False,
         Xw = X
         yw = y
 
-    # FIT (WEIGHTED) LEAST SQUARES REGRESSION USING SCIPY.LINALG.LSTST
+    # FIT (WEIGHTED) LEAST SQUARES REGRESSION USING NP.LINALG.LSTST
     coef, ss_res, rank, _ = np.linalg.lstsq(Xw, yw, rcond=None)
+    ss_res = ss_res[0] if ss_res.shape == (1,) else ss_res
     if coef_only:
         return coef
     calc_ss_res = False
     if rank < Xw.shape[1]:
+        # in this case, ss_res is of shape (0,), i.e., an empty array
         warnings.warn('Design matrix supplied with `X` parameter is rank '
                       f'deficient (rank {rank} with {Xw.shape[1]} columns). '
                       'That means that one or more of the columns in `X` '
@@ -415,6 +417,7 @@ def linear_regression(X, y, add_intercept=True, weights=None, coef_only=False,
     # Degrees of freedom
     df_model = rank - constant
     df_resid = n - rank
+
     # Calculate predicted values and (weighted) residuals
     pred = Xw @ coef
     resid = yw - pred

--- a/pingouin/regression.py
+++ b/pingouin/regression.py
@@ -400,7 +400,7 @@ def linear_regression(X, y, add_intercept=True, weights=None, coef_only=False,
         yw = y
 
     # FIT (WEIGHTED) LEAST SQUARES REGRESSION USING SCIPY.LINALG.LSTST
-    coef, ss_res, rank, _ = np.linalg.lstsq(Xw, yw)
+    coef, ss_res, rank, _ = np.linalg.lstsq(Xw, yw, rcond=None)
     if coef_only:
         return coef
     calc_ss_res = False

--- a/pingouin/regression.py
+++ b/pingouin/regression.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import pandas_flavor as pf
 from scipy.stats import t, norm
-from scipy.linalg import pinv, pinvh, lstsq
+from scipy.linalg import pinv, pinvh
 from pingouin.config import options
 from pingouin.utils import remove_na as rm_na
 from pingouin.utils import _flatten_list as _fl
@@ -120,7 +120,7 @@ def linear_regression(X, y, add_intercept=True, weights=None, coef_only=False,
     -----
     The :math:`\\beta` coefficients are estimated using an ordinary least
     squares (OLS) regression, as implemented in the
-    :py:func:`scipy.linalg.lstsq` function. The OLS method minimizes
+    :py:func:`np.linalg.lstsq` function. The OLS method minimizes
     the sum of squared residuals, and leads to a closed-form expression for
     the estimated :math:`\\beta`:
 
@@ -400,7 +400,7 @@ def linear_regression(X, y, add_intercept=True, weights=None, coef_only=False,
         yw = y
 
     # FIT (WEIGHTED) LEAST SQUARES REGRESSION USING SCIPY.LINALG.LSTST
-    coef, ss_res, rank, _ = lstsq(Xw, yw)
+    coef, ss_res, rank, _ = np.linalg.lstsq(Xw, yw)
     if coef_only:
         return coef
     calc_ss_res = False

--- a/pingouin/regression.py
+++ b/pingouin/regression.py
@@ -1,4 +1,5 @@
 import itertools
+import warnings
 import numpy as np
 import pandas as pd
 import pandas_flavor as pf
@@ -402,15 +403,24 @@ def linear_regression(X, y, add_intercept=True, weights=None, coef_only=False,
     coef, ss_res, rank, _ = lstsq(Xw, yw)
     if coef_only:
         return coef
+    calc_ss_res = False
+    if rank < Xw.shape[1]:
+        warnings.warn('Design matrix supplied with `X` parameter is rank '
+                      f'deficient (rank {rank} with {Xw.shape[1]} columns. '
+                      'That means that one or more of the columns in `X` '
+                      'are a linear combination of one of more of the '
+                      'other columns.')
+        calc_ss_res = True
 
     # Degrees of freedom
     df_model = rank - constant
     df_resid = n - p
-
     # Calculate predicted values and (weighted) residuals
     pred = Xw @ coef
     resid = yw - pred
-    # ss_res = (resid ** 2).sum()
+    if calc_ss_res:
+        # In case we did not get ss_res from lstsq due to rank deficiency
+        ss_res = (resid ** 2).sum()
 
     # Calculate total (weighted) sums of squares and R^2
     ss_tot = yw @ yw

--- a/pingouin/regression.py
+++ b/pingouin/regression.py
@@ -414,7 +414,7 @@ def linear_regression(X, y, add_intercept=True, weights=None, coef_only=False,
 
     # Degrees of freedom
     df_model = rank - constant
-    df_resid = n - p
+    df_resid = n - rank
     # Calculate predicted values and (weighted) residuals
     pred = Xw @ coef
     resid = yw - pred

--- a/pingouin/tests/test_regression.py
+++ b/pingouin/tests/test_regression.py
@@ -131,7 +131,8 @@ class TestRegression(TestCase):
         y = rng.randn(n)
 
         with pytest.warns(UserWarning,
-                          match='rank deficient (rank 5 with 6 columns'):
+                          match='(rank 5 with 6 columns)'):
+
             res_pingouin = linear_regression(X, y, add_intercept=True)
 
         X_with_intercept = sm.add_constant(X)

--- a/pingouin/tests/test_regression.py
+++ b/pingouin/tests/test_regression.py
@@ -141,27 +141,16 @@ class TestRegression(TestCase):
         np.testing.assert_allclose(res_pingouin.residuals_, res_sm.resid)
         np.testing.assert_allclose(res_pingouin['coef'], res_sm.params)
         np.testing.assert_allclose(res_pingouin['r2'][0], res_sm.rsquared)
-
-        # Some parameters differ within 0.001 to 0.05 tolerance
-        rtol = 0.05
-        np.testing.assert_allclose(res_pingouin['T'], res_sm.tvalues,
-                                   rtol=rtol)
-        np.testing.assert_allclose(res_pingouin['se'], res_sm.bse,
-                                   rtol=rtol)
-        np.testing.assert_allclose(res_pingouin['pval'], res_sm.pvalues,
-                                   rtol=rtol)
-        np.testing.assert_allclose(res_pingouin['CI[2.5%]'],
-                                   res_sm.conf_int()[:, 0],
-                                   rtol=rtol)
-        np.testing.assert_allclose(res_pingouin['CI[97.5%]'],
-                                   res_sm.conf_int()[:, 1],
-                                   rtol=rtol)
-
-        # some parameters do not match at all: diff ~0.7
-        rtol = 0.7
         np.testing.assert_allclose(res_pingouin['adj_r2'][0],
-                                   res_sm.rsquared_adj,
-                                   rtol=rtol)
+                                   res_sm.rsquared_adj)
+        np.testing.assert_allclose(res_pingouin['T'], res_sm.tvalues)
+        np.testing.assert_allclose(res_pingouin['se'], res_sm.bse)
+        np.testing.assert_allclose(res_pingouin['pval'], res_sm.pvalues)
+        np.testing.assert_allclose(res_pingouin['CI[2.5%]'],
+                                   res_sm.conf_int()[:, 0])
+        np.testing.assert_allclose(res_pingouin['CI[97.5%]'],
+                                   res_sm.conf_int()[:, 1])
+
 
         # Relative importance
         # Compare to R package relaimpo


### PR DESCRIPTION
closes #130 

For now I opted to only return the coefficients in case a rank deficient design matrix is detected.

The basic error of pingouin is its inability to handle the `residues` return parameter of `lstsq` whenever the design matrix is rank deficient. In that case, `residues` is an empty array `array([], dtype=float64)` instead of a float.

One option apart from warning and simply returning the coefficients only could be to "revive" the currently commented line from line 413(old) / 422(new): `    # ss_res = (resid ** 2).sum()`

Something like:

```Python
    # FIT (WEIGHTED) LEAST SQUARES REGRESSION USING SCIPY.LINALG.LSTST
    coef, ss_res, rank, _ = lstsq(Xw, yw)
    if coef_only:
        return coef
    calc_ss_res = False
    if rank < Xw.shape[1]:
        warnings.warn('Design matrix supplied with `X` parameter is rank '
                      f'deficient (rank {rank} with {Xw.shape[1]} columns. '
                      'That means that one or more of the columns in `X` '
                      'are a linear combination of one of more of the '
                      'other columns.'')
        calc_ss_res = True

    # Degrees of freedom
    df_model = rank - constant
    df_resid = n - p
    # Calculate predicted values and (weighted) residuals
    pred = Xw @ coef
    resid = yw - pred
    if calc_ss_res:
        ss_res = (resid ** 2).sum()
```

I played around with that, and it seems to be producing the same results as statsmodels. Try for yourself if you'd like:

```Python
import numpy as np 
import pingouin 
import statsmodels.api as sm 

# make up some random data and a design matrix for multiple linear regression 
n = 100  
y = np.random.randn(n) 
X = np.vstack([np.random.permutation([0, 1, 0, 0, 0]) for i in range(n)]) 

# try with pingouin (use patch from code example above)
results_pingouin = pingouin.linear_regression(X, y, add_intercept=True) 
print(results_pingouin)

# try with statsmodels
X_with_intercept = sm.add_constant(X) 
model = sm.OLS(endog=y, exog=X_with_intercept) 
results_sm = model.fit() 
print(results_sm.summary())

# compare residuals
np.allclose(results_pingouin.residuals_, results_sm.resid)  # True
np.allclose(results_pingouin.coef.to_numpy(), results_sm.params)  # True
```

Let me know what you think :-)
