### PR TITLE
[BUGFIX] Add safety check for `tail` argument in corr func

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,15 @@
 What's new
 ##########
 
+v0.3.11 (unreleased)
+--------------------
+
+**Bugfixes**
+
+a. Passing a wrong ``tail`` argument to :py:func:`pingouin.correlation.corr` now *always* raises an error (see `PR 160 <https://github.com/raphaelvallat/pingouin/pull/160>`_).
+   In previous versions of ``pingouin``, using any ``method`` other than ``"pearson"`` and a wrong ``tail`` argument such as ``"two-tailed"`` or ``"both"``
+   (instead of the correct ``"two-sided"``) may have resulted in silently returning a one-sided p-value.
+
 v0.3.10 (February 2021)
 -----------------------
 

--- a/pingouin/correlation.py
+++ b/pingouin/correlation.py
@@ -509,7 +509,7 @@ def corr(x, y, tail='two-sided', method='pearson', **kwargs):
     assert x.ndim == y.ndim == 1, 'x and y must be 1D array.'
     assert x.size == y.size, 'x and y must have the same length.'
     _msg = 'tail must be "two-sided" or "one-sided".'
-    assert tail.lower() in ['two-sided', 'one-sided'], _msg
+    assert tail in ['two-sided', 'one-sided'], _msg
 
     # Remove rows with missing values
     x, y = remove_na(x, y, paired=True)
@@ -531,7 +531,7 @@ def corr(x, y, tail='two-sided', method='pearson', **kwargs):
     elif method == 'skipped':
         r, pval, outliers = skipped(x, y, **kwargs)
     else:
-        raise ValueError('Method not recognized.')
+        raise ValueError(f'Method "{method}" not recognized.')
 
     if np.isnan(r):
         # Correlation failed -- new in version v0.3.4, instead of raising an

--- a/pingouin/correlation.py
+++ b/pingouin/correlation.py
@@ -508,6 +508,8 @@ def corr(x, y, tail='two-sided', method='pearson', **kwargs):
     y = np.asarray(y)
     assert x.ndim == y.ndim == 1, 'x and y must be 1D array.'
     assert x.size == y.size, 'x and y must have the same length.'
+    _msg = 'tail must be "two-sided" or "one-sided".'
+    assert tail.lower() in ['two-sided', 'one-sided'], _msg
 
     # Remove rows with missing values
     x, y = remove_na(x, y, paired=True)


### PR DESCRIPTION
I noticed a missing safety check in the corr function and add it in this PR.

#### does not raise an issue (notice the wrong `tail` arg)

```python
stat_bnt = pingouin.correlation.corr(
    _curdat[colname], _curdat["correct_choice"], method="kendall", tail="two-tailed"
)
```

#### raises an issue (`tail` arg still wrong, but corr method changed)

```python
stat_bnt = pingouin.correlation.corr(
    _curdat[colname], _curdat["correct_choice"], method="pearson", tail="two-tailed"
)
```


So the wrong input was sometimes still called, but not always. With my changes, it is always called.

This probably fixes a silent bug: When users used `kendall` as the `method`, and specified `two-tailed` (instead of the correct `two-sided`), no error was raised ... and a one-sided p value was returned :skull: :grimacing: 

see:

https://github.com/raphaelvallat/pingouin/blob/0c3bf73629ffb1826dc298f0ee498e0784222b5e/pingouin/correlation.py#L556

if it's "two-tailed", it's treated the same way as "one-sided", and the missing safety check (now added in this PR) prevented the wrong "two-tailed" argument from being caught early.