### PR TITLE
Improved error message of partial_corr when x is in covar

### DIFF
--- a/pingouin/correlation.py
+++ b/pingouin/correlation.py
@@ -719,6 +719,9 @@ def partial_corr(data=None, x=None, y=None, covar=None, x_covar=None,
     assert x != covar, 'x and covar must be independent'
     assert y != covar, 'y and covar must be independent'
     assert x != y, 'x and y must be independent'
+    if isinstance(covar, list):
+        assert x not in covar, 'x and covar must be independent'
+        assert y not in covar, 'y and covar must be independent'
     # Check that columns exist
     col = _flatten_list([x, y, covar, x_covar, y_covar])
     if isinstance(covar, str):

--- a/pingouin/tests/test_correlation.py
+++ b/pingouin/tests/test_correlation.py
@@ -92,6 +92,9 @@ class TestCorrelation(TestCase):
                      y_covar=['cv2', 'cv3'], method='spearman')
         with pytest.raises(ValueError):
             partial_corr(data=df, x='x', y='y', covar='cv2', x_covar='cv1')
+        with pytest.raises(AssertionError) as error_info:
+            partial_corr(data=df, x='cv1', y='y', covar=['cv1', 'cv2'])
+        assert str(error_info.value) == "x and covar must be independent"
 
     def test_rmcorr(self):
         """Test function rm_corr"""


### PR DESCRIPTION
`import pingouin as pg
df = pg.read_dataset('partial_corr')
pg.partial_corr(data=df, x='cv1', y='y', covar=['cv1'])`

This code example gives an error - as it should since x is in covar. However the error message is rather non-intuitive:
```
Traceback (most recent call last):
  File "[FILE_PATH]", line 3, in <module>
    pg.partial_corr(data=df, x='cv1', y='y', covar=['cv1'])
  File "[PYTHON_LIB_PATH]\pingouin\correlation.py", line 759, in partial_corr
    return corr(res_x, res_y, method=method, tail=tail)
  File "[PYTHON_LIB_PATH]\pingouin\correlation.py", line 509, in corr
    assert x.ndim == y.ndim == 1, 'x and y must be 1D array.'
AssertionError: x and y must be 1D array.
```

If covar is a string instead of a list of strings, then one gets this error message
```
Traceback (most recent call last):
  File "[FILE_PATH]", line 3, in <module>
    pg.partial_corr(data=df, x='cv1', y='y', covar='cv1')
  File "[PYTHON_LIB_PATH]\pingouin\correlation.py", line 717, in partial_corr
    assert x != covar, 'x and covar must be independent'
AssertionError: x and covar must be independent
```
I think that error message is great and to the point! With this PR partial_corr will throw the 'x and covar must be independent' error message even when covar is a list of strings.