### PR TITLE
Moore-rayleigh

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -52,6 +52,7 @@ Circular
     circ_mean
     circ_r
     circ_rayleigh
+    circ_moore_rayleigh
     circ_vtest
 
 Contingency

--- a/pingouin/circular.py
+++ b/pingouin/circular.py
@@ -11,7 +11,7 @@ from scipy.stats import norm
 from .utils import remove_na
 
 __all__ = ["convert_angles", "circ_axial", "circ_mean", "circ_r", "circ_corrcc", "circ_corrcl",
-           "circ_rayleigh", "circ_vtest"]
+           "circ_rayleigh", "circ_moore_rayleigh", "circ_vtest"]
 
 
 ###############################################################################
@@ -672,6 +672,49 @@ def circ_rayleigh(angles, w=None, d=None):
     # Compute p value using approxation in Zar (1999), p. 617
     pval = np.exp(np.sqrt(1 + 4 * n + 4 * (n**2 - R**2)) - (1 + 2 * n))
     return z, pval
+
+
+def circ_moore_rayleigh(angles, w):
+    """Moore's modified Rayleigh test for non-uniformity of vector data.
+
+    Parameters
+    ----------
+    angles : 1-D array_like
+        Samples of angles in radians. The range of ``angles`` must be either
+        :math:`[0, 2\\pi]` or :math:`[-\\pi, \\pi]`. If ``angles`` is not
+        expressed in radians (e.g. degrees or 24-hours), please use the
+        :py:func:`pingouin.convert_angles` function prior to using the present
+        function.
+    w : 1-D array_like
+        Vector weights. Should be the same length as ``angles``.
+
+    Returns
+    -------
+    r : float
+        R\*-statistic
+    pval : float
+        P-value
+
+    Notes
+    -----
+    The Moore's modified Rayleigh test is a non-parametric analogue of the Rayleigh test
+    for weighted vector data (Moore, 1980).
+
+    H0: the population is uniformly distributed around the circle
+    HA: the populatoin is not distributed uniformly around the circle
+
+    Examples
+    --------
+    1. Simple Moore's modified Rayleigh test for non-uniformity of vector data.
+
+    >>> from pingouin import circ_moore_rayleigh
+    >>> x = [-3.1415, -1.5708, -1.8326, -2.1293, 1.4835, 2.7925, -0.9948, 3.1415]
+    >>> w = [.5, .7, .2, .3, .8, .9, 1., .2]
+    >>> r, pval = circ_moore_rayleigh(x, w)
+    >>> print(round(r, 3), round(pval, 3))
+    0.519 0.508
+    """
+    pass
 
 
 def circ_vtest(angles, dir=0., w=None, d=None):

--- a/pingouin/circular.py
+++ b/pingouin/circular.py
@@ -714,7 +714,24 @@ def circ_moore_rayleigh(angles, w):
     >>> print(round(r, 3), round(pval, 3))
     0.519 0.508
     """
-    pass
+    angles = np.asarray(angles)
+    _checkangles(angles)  # Check that angles is in radians
+    assert len(angles) == len(w), "Input dimensions do not match"
+
+    n = len(angles)
+
+    # Compute Moore's modified Rayleigh statistic
+    ranked = angles[np.argsort(w)]
+    rank_weights = np.arange(1, n + 1)
+
+    x = np.sum(rank_weights * np.cos(ranked))
+    y = np.sum(rank_weights * np.sin(ranked))
+
+    r = np.sqrt(x * x + y * y) / n ** 1.5
+
+    # Compute p value using approxation in Moore (1980) (eq. 3.3)
+    pval = np.exp(-6 * (r ** 2) * (n ** 2) / ((n + 1) * (2 * n + 1)))
+    return r, pval
 
 
 def circ_vtest(angles, dir=0., w=None, d=None):

--- a/pingouin/circular.py
+++ b/pingouin/circular.py
@@ -697,11 +697,16 @@ def circ_moore_rayleigh(angles, w):
 
     Notes
     -----
-    The Moore's modified Rayleigh test is a non-parametric analogue of the Rayleigh test
-    for weighted vector data (Moore, 1980).
+    The Moore's modified Rayleigh test [1]_ is a non-parametric analogue of the
+    Rayleigh test for weighted vector data.
 
     H0: the population is uniformly distributed around the circle
     HA: the populatoin is not distributed uniformly around the circle
+
+    References
+    ----------
+    .. [1] Moore, B. R. (1980). A modification of the Rayleigh test for vector data.
+           Biometrika, 67(1), 175-180.
 
     Examples
     --------

--- a/pingouin/tests/test_circular.py
+++ b/pingouin/tests/test_circular.py
@@ -5,7 +5,7 @@ from scipy.stats import circmean
 from pingouin import read_dataset
 from pingouin.circular import convert_angles, _checkangles
 from pingouin.circular import (circ_axial, circ_corrcc, circ_corrcl, circ_mean,
-                               circ_r, circ_rayleigh, circ_vtest)
+                               circ_r, circ_rayleigh, circ_moore_rayleigh, circ_vtest)
 
 np.random.seed(123)
 a1 = [-1.2, 2.5, 3.1, -3.1, 0.2, -0.2]   # -np.pi / pi
@@ -133,6 +133,15 @@ class TestCircular(TestCase):
         z, pval = circ_rayleigh(x, w=[.1, .2, .3, .4, .5], d=0.2)
         assert round(z, 3) == 0.278
         assert round(pval, 4) == 0.8070
+
+    def test_circ_moore_rayleigh(self):
+        """Test function circ_moore_rayleigh."""
+        x = [0.785, 1.570, 3.141, 0.839, 5.934]
+        w = [.1, .2, .3, .4, .5]
+        r, pval = circ_moore_rayleigh(x, w)
+        # Compare with Oriana
+        assert round(r, 3) == 0.577
+        assert round(pval, 3) == 0.469
 
     def test_circ_vtest(self):
         """Test function circ_vtest."""


### PR DESCRIPTION
This PR implements the Moore's modified Rayleigh test described in Moore, B. R. (1980). A modification of the Rayleigh test for vector data. Biometrika, 67(1), 175-180. Addresses part of #214.  I've tried to follow your style for code and documentation, and I've included tests based on R* values obtained from the Oriana circular statistics program, and manually calculated p-values.

This test is slightly obscure (in fact, I couldn't find it in any other statistics library...) although it's used a fair bit in animal migration research. The lack of an open-source implementation was bugging me, so I thought I would contribute to an existing library rather than start my own. Cheers!