### PR TITLE
Fixes for dependency (scipy and pandas) updates

### DIFF
--- a/pingouin/correlation.py
+++ b/pingouin/correlation.py
@@ -645,7 +645,7 @@ def corr(x, y, alternative='two-sided', method='pearson', **kwargs):
         stats['BF10'] = bayesfactor_pearson(r, n_clean, alternative=alternative)
 
     # Convert to DataFrame
-    stats = pd.DataFrame.from_records(stats, index=[method])
+    stats = pd.DataFrame(stats, index=[method])
 
     # Define order
     col_keep = ['n', 'outliers', 'r', 'CI95%', 'p-val', 'BF10', 'power']
@@ -863,7 +863,7 @@ def partial_corr(data=None, x=None, y=None, covar=None, x_covar=None,
     }
 
     # Convert to DataFrame
-    stats = pd.DataFrame.from_records(stats, index=[method])
+    stats = pd.DataFrame(stats, index=[method])
 
     # Define order
     col_keep = ['n', 'r', 'CI95%', 'p-val']

--- a/pingouin/pairwise.py
+++ b/pingouin/pairwise.py
@@ -458,8 +458,8 @@ def pairwise_ttests(data=None, dv=None, between=None, within=None, subject=None,
 
             # Append empty rows
             idxiter = np.arange(nrows, nrows + ncombs)
-            stats = stats.append(
-                pd.DataFrame(columns=stats.columns, index=idxiter), ignore_index=True)
+            stats = stats.reindex(stats.index.union(idxiter))
+
             # Update other columns
             stats.loc[idxiter, 'Contrast'] = factors[0] + ' * ' + factors[1]
             stats.loc[idxiter, 'Time'] = combs[:, 0]

--- a/pingouin/parametric.py
+++ b/pingouin/parametric.py
@@ -310,7 +310,7 @@ def ttest(x, y, paired=False, alternative='two-sided', correction='auto', r=.707
 
     # Convert to dataframe
     col_order = ['T', 'dof', 'alternative', 'p-val', ci_name, 'cohen-d', 'BF10', 'power']
-    stats = pd.DataFrame.from_records(stats, columns=col_order, index=['T-test'])
+    stats = pd.DataFrame(stats, columns=col_order, index=['T-test'])
     return _postprocess_dataframe(stats)
 
 

--- a/pingouin/parametric.py
+++ b/pingouin/parametric.py
@@ -198,8 +198,12 @@ def ttest(x, y, paired=False, alternative='two-sided', correction='auto', r=.707
     array([1.971859, 0.057056])
     """
     from scipy.stats import t, ttest_rel, ttest_ind, ttest_1samp
-    from scipy.stats.stats import (_unequal_var_ttest_denom,
-                                   _equal_var_ttest_denom)
+    try:
+        from scipy.stats._stats_py import (_unequal_var_ttest_denom,
+                                       _equal_var_ttest_denom)
+    except ImportError:  # Fallback for scipy<1.8.0
+        from scipy.stats.stats import (_unequal_var_ttest_denom,
+                                       _equal_var_ttest_denom)
     from pingouin import (power_ttest, power_ttest2n, compute_effsize)
 
     # Check arguments

--- a/pingouin/plotting.py
+++ b/pingouin/plotting.py
@@ -334,6 +334,11 @@ def qqplot(x, dist='norm', sparams=(), confidence=.95, figsize=(5, 4),
         >>> sns.set_style('darkgrid')
         >>> ax = pg.qqplot(x, dist='norm', sparams=(mean, std))
     """
+    try:
+        from scipy.stats._morestats import _add_axis_labels_title
+    except ImportError:  # Fallback for scipy<1.8.0
+        from scipy.stats.morestats import _add_axis_labels_title
+
     if isinstance(dist, str):
         dist = getattr(stats, dist)
 
@@ -371,10 +376,10 @@ def qqplot(x, dist='norm', sparams=(), confidence=.95, figsize=(5, 4),
 
     ax.plot(theor, observed, 'bo')
 
-    stats.morestats._add_axis_labels_title(ax,
-                                           xlabel='Theoretical quantiles',
-                                           ylabel='Ordered quantiles',
-                                           title='Q-Q Plot')
+    _add_axis_labels_title(ax,
+                           xlabel='Theoretical quantiles',
+                           ylabel='Ordered quantiles',
+                           title='Q-Q Plot')
 
     # Add diagonal line
     end_pts = [ax.get_xlim(), ax.get_ylim()]


### PR DESCRIPTION
Fixed the bug from https://github.com/raphaelvallat/pingouin/issues/232

To pass unit tests I also:
Implemented your fix @raphaelvallat from https://github.com/raphaelvallat/pingouin/issues/227

DataFrame.apply() does not copy dtypes for some reason ant it is also deprecated (https://pandas.pydata.org/pandas-docs/version/1.4.0/whatsnew/v1.4.0.html), causing unit tests to fail, so I replaced the following line
https://github.com/raphaelvallat/pingouin/blob/dcfdc82bbc7f1ba5991b80717a5ca156617443e8/pingouin/pairwise.py#L461-L462
with
```py
stats = stats.reindex(stats.index.union(idxiter))
```