### PR TITLE
Remove dependency on scipy._morestats

### DIFF
--- a/pingouin/plotting.py
+++ b/pingouin/plotting.py
@@ -334,11 +334,6 @@ def qqplot(x, dist='norm', sparams=(), confidence=.95, figsize=(5, 4),
         >>> sns.set_style('darkgrid')
         >>> ax = pg.qqplot(x, dist='norm', sparams=(mean, std))
     """
-    try:
-        from scipy.stats._morestats import _add_axis_labels_title
-    except ImportError:  # Fallback for scipy<1.8.0
-        from scipy.stats.morestats import _add_axis_labels_title
-
     if isinstance(dist, str):
         dist = getattr(stats, dist)
 
@@ -376,10 +371,9 @@ def qqplot(x, dist='norm', sparams=(), confidence=.95, figsize=(5, 4),
 
     ax.plot(theor, observed, 'bo')
 
-    _add_axis_labels_title(ax,
-                           xlabel='Theoretical quantiles',
-                           ylabel='Ordered quantiles',
-                           title='Q-Q Plot')
+    ax.set_xlabel('Theoretical quantiles')
+    ax.set_ylabel('Ordered quantiles')
+    ax.set_title('Q-Q Plot')
 
     # Add diagonal line
     end_pts = [ax.get_xlim(), ax.get_ylim()]


### PR DESCRIPTION
It is clear in this case that labels and title are added to an axis object. The call to `scipy._morestats` can therefore be replaced with direct calls of the matplotlib functions.