### PR TITLE
better docs: aligned the comment and code

### DIFF
--- a/notebooks/04_Correlations.ipynb
+++ b/notebooks/04_Correlations.ipynb
@@ -1358,7 +1358,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Great! What about if I am interested in looking at `Age` and `BMI` on the one hand and the personality dimensions on the other hand? That's also very easy:"
+    "Great! What about if I am interested in looking at `Age` and `Gender` on the one hand and the personality dimensions on the other hand? That's also very easy:"
    ]
   },
   {


### PR DESCRIPTION
the comment spoke about `BMI`, yet the code used `gender`; aligned now