### PR TITLE
Use scikit-learn<1.1.0

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,6 +27,10 @@ b. Allow :py:func:`pingouin.bayesfactor_binom` to take Beta alternative model. `
 c. Allow keyword arguments for logistic regression in :py:func:`pingouin.mediation_analysis`. `PR 245 <https://github.com/raphaelvallat/pingouin/pull/245>`_.
 d. Major speed improvements for the Holm and FDR correction in :py:func:`pingouin.bayesfactor_binom`. `PR 271 <https://github.com/raphaelvallat/pingouin/pull/271>`_.
 
+**Dependencies**
+
+a. Force scikit-learn<1.1.0 to avoid bug in :py:func:`pingouin.logistic_regression`. `PR 272 <https://github.com/raphaelvallat/pingouin/issues/272>`_.
+
 v0.5.1 (February 2022)
 ----------------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pandas>=1.0
 matplotlib>=3.0.2
 seaborn>=0.11
 statsmodels>=0.13
-scikit-learn
+scikit-learn<1.1.0
 pandas_flavor>=0.2.0
 outdated
 tabulate

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ INSTALL_REQUIRES = [
     'matplotlib>=3.0.2',
     'seaborn>=0.11',
     'statsmodels>=0.13',
-    'scikit-learn',
+    'scikit-learn<1.1.0',
     'pandas_flavor>=0.2.0',
     'outdated',
     'tabulate'


### PR DESCRIPTION
Temporary fix for #272 

We will need to revert these changes when the next stable version of scikit-learn is released (1.1.2): https://github.com/scikit-learn/scikit-learn/pull/23608