### PR TITLE
Add support for DataMatrix objects

### DIFF
--- a/pingouin/nonparametric.py
+++ b/pingouin/nonparametric.py
@@ -536,7 +536,7 @@ def kruskal(data=None, dv=None, between=None, detailed=False):
     Kruskal  Hair color      3  10.58863  0.014172
     """
     # Check data
-    _check_dataframe(dv=dv, between=between, data=data, effects="between")
+    data = _check_dataframe(dv=dv, between=between, data=data, effects="between")
 
     # Remove NaN values
     data = data[[dv, between]].dropna()
@@ -686,7 +686,7 @@ def friedman(data=None, dv=None, within=None, subject=None, method="chisq"):
         subject, within, dv = "Subj", "Within", "DV"
 
     # Check dataframe
-    _check_dataframe(dv=dv, within=within, data=data, subject=subject, effects="within")
+    data = _check_dataframe(dv=dv, within=within, data=data, subject=subject, effects="within")
     assert not data[within].isnull().any(), "Cannot have missing values in `within`."
     assert not data[subject].isnull().any(), "Cannot have missing values in `subject`."
 
@@ -822,7 +822,7 @@ def cochran(data=None, dv=None, within=None, subject=None):
         subject, within, dv = "Subj", "Within", "DV"
 
     # Check data
-    _check_dataframe(dv=dv, within=within, data=data, subject=subject, effects="within")
+    data = _check_dataframe(dv=dv, within=within, data=data, subject=subject, effects="within")
     assert not data[within].isnull().any(), "Cannot have missing values in `within`."
     assert not data[subject].isnull().any(), "Cannot have missing values in `subject`."
 

--- a/pingouin/pairwise.py
+++ b/pingouin/pairwise.py
@@ -268,7 +268,7 @@ def pairwise_tests(
     from .nonparametric import wilcoxon, mwu
 
     # Safety checks
-    _check_dataframe(
+    data = _check_dataframe(
         dv=dv, between=between, within=within, subject=subject, effects="all", data=data
     )
     assert alternative in [
@@ -852,7 +852,7 @@ def pairwise_gameshowell(data=None, dv=None, between=None, effsize="hedges"):
     2  Chinstrap     Gentoo  3733.088  5076.016 -1342.928  65.103 -20.628  170.404  0.00  -3.105
     """
     # Check the dataframe
-    _check_dataframe(dv=dv, between=between, effects="between", data=data)
+    data = _check_dataframe(dv=dv, between=between, effects="between", data=data)
 
     # Reset index (avoid duplicate axis error)
     data = data.reset_index(drop=True)

--- a/pingouin/parametric.py
+++ b/pingouin/parametric.py
@@ -523,7 +523,7 @@ def rm_anova(
         subject, within, dv = "Subj", "Within", "DV"
 
     # Check dataframe
-    _check_dataframe(dv=dv, within=within, data=data, subject=subject, effects="within")
+    data = _check_dataframe(dv=dv, within=within, data=data, subject=subject, effects="within")
 
     assert not data[within].isnull().any(), "Cannot have missing values in `within`."
     assert not data[subject].isnull().any(), "Cannot have missing values in `subject`."
@@ -673,7 +673,7 @@ def rm_anova2(data=None, dv=None, within=None, subject=None, effsize="ng2"):
     a, b = within
 
     # Validate the dataframe
-    _check_dataframe(dv=dv, within=within, data=data, subject=subject, effects="within")
+    data = _check_dataframe(dv=dv, within=within, data=data, subject=subject, effects="within")
 
     assert not data[a].isnull().any(), "Cannot have missing values in %s" % a
     assert not data[b].isnull().any(), "Cannot have missing values in %s" % b
@@ -974,7 +974,7 @@ def anova(data=None, dv=None, between=None, ss_type=2, detailed=False, effsize="
             return anovan(dv=dv, between=between, data=data, ss_type=ss_type, effsize=effsize)
 
     # Check data
-    _check_dataframe(dv=dv, between=between, data=data, effects="between")
+    data = _check_dataframe(dv=dv, between=between, data=data, effects="between")
 
     # Drop missing values
     data = data[[dv, between]].dropna()
@@ -1046,7 +1046,7 @@ def anova2(data=None, dv=None, between=None, ss_type=2, effsize="np2"):
     by the :py:func:`pingouin.anova` function.
     """
     # Validate the dataframe
-    _check_dataframe(dv=dv, between=between, data=data, effects="between")
+    data = _check_dataframe(dv=dv, between=between, data=data, effects="between")
 
     assert len(between) == 2, "Must have exactly two between-factors variables"
     fac1, fac2 = between
@@ -1140,7 +1140,7 @@ def anovan(data=None, dv=None, between=None, ss_type=2, effsize="np2"):
     from statsmodels.formula.api import ols
 
     # Validate the dataframe
-    _check_dataframe(dv=dv, between=between, data=data, effects="between")
+    data = _check_dataframe(dv=dv, between=between, data=data, effects="between")
     all_cols = _flatten_list([dv, between])
     bad_chars = [",", "(", ")", ":"]
     if not all([c not in v for c in bad_chars for v in all_cols]):
@@ -1323,7 +1323,7 @@ def welch_anova(data=None, dv=None, between=None):
     0  Hair color      3  8.329841  5.890115  0.018813  0.575962
     """
     # Check data
-    _check_dataframe(dv=dv, between=between, data=data, effects="between")
+    data = _check_dataframe(dv=dv, between=between, data=data, effects="between")
 
     # Reset index (avoid duplicate axis error)
     data = data.reset_index(drop=True)
@@ -1472,7 +1472,7 @@ def mixed_anova(
         )
 
     # Check data
-    _check_dataframe(
+    data = _check_dataframe(
         dv=dv, within=within, between=between, data=data, subject=subject, effects="interaction"
     )
 

--- a/pingouin/plotting.py
+++ b/pingouin/plotting.py
@@ -555,7 +555,7 @@ def plot_paired(
         )
 
     # Validate args
-    _check_dataframe(data=data, dv=dv, within=within, subject=subject, effects="within")
+    data = _check_dataframe(data=data, dv=dv, within=within, subject=subject, effects="within")
 
     # Pivot and melt the table. This has several effects:
     # 1) Force missing values to be explicit (a NaN cell is created)

--- a/pingouin/utils.py
+++ b/pingouin/utils.py
@@ -336,7 +336,8 @@ def _check_eftype(eftype):
         return False
 
 
-def _check_dataframe(data=None, dv=None, between=None, within=None, subject=None, effects=None):
+def _check_dataframe(data=None, dv=None, between=None,
+                     within=None, subject=None, effects=None):
     """Checks whether data is a dataframe or can be converted to a dataframe.
     If successful, a dataframe is returned. If not successful, a ValueError is
     raised.
@@ -350,14 +351,17 @@ def _check_dataframe(data=None, dv=None, between=None, within=None, subject=None
             try:
                 from datamatrix import DataMatrix, convert as cnv
             except ImportError:
-                raise ValueError("Failed to convert object to pandas dataframe (DataMatrix not available)")
+                raise ValueError(
+                    "Failed to convert object to pandas dataframe (DataMatrix not available)")
             else:
                 if isinstance(data, DataMatrix):
                     data = cnv.to_pandas(data)
                 else:
-                    raise ValueError("Data must be a pandas dataframe or compatible object.")
+                    raise ValueError(
+                        "Data must be a pandas dataframe or compatible object.")
         else:
-            raise ValueError("Data must be a pandas dataframe or compatible object.")
+            raise ValueError(
+                "Data must be a pandas dataframe or compatible object.")
     # Check that both dv and data are provided.
     if any(v is None for v in [dv, data]):
         raise ValueError("DV and data must be specified")
@@ -380,8 +384,10 @@ def _check_dataframe(data=None, dv=None, between=None, within=None, subject=None
     if effects == "interaction":
         for input in [within, between]:
             if not isinstance(input, (str, int, list)):
-                raise ValueError("within and between must be specified when effects=interaction")
+                raise ValueError(
+                    "within and between must be specified when effects=interaction")
     return data
+
 
 ###############################################################################
 # DEPENDENCIES


### PR DESCRIPTION
[DataMatrix](https://pydatamatrix.eu/) objects are similar to DataFrame objects and can be easily converted. This PR patches `_check_dataframe()` such that it performs this conversion if necessary, while avoiding unnecessary overhead (such as importing DataMatrix if not necessary). This also opens the door for converting other DataFrame-like objects, such as structured arrays, etc. However, this is not implemented here.)

PS. The linter complains that I should reformat the code. I'm not sure how to fix that, because it's already pep-8 compatible, as far as I can tell (?).

