### PR TITLE
Add new function for pairwise T-tests between columns of a dataframe (pingouin.ptests)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -329,17 +329,27 @@ The `pingouin.normality` function works with lists, arrays, or pandas DataFrame 
   Y    Z    pearson   two-sided       30  0.020  [-0.34  0.38]    0.916   0.228    0.051
   ===  ===  ========  =============  ===  =====  =============  =======  ======  =======
 
-10. Convert between effect sizes
-################################
+------------
+
+10.  Pairwise T-test between columns of a dataframe
+###################################################
 
 .. code-block:: python
 
-    # Convert from Cohen's d to Hedges' g
-    pg.convert_effsize(0.4, 'cohen', 'hedges', nx=10, ny=12)
+    data.ptests(paired=True, stars=False)
 
-.. parsed-literal::
+.. table:: Pairwise T-tests, with T-values on the lower triangle and p-values on the upper triangle
+  :widths: auto
 
-    0.384
+  ====  ======  ======  =====
+  ..    X       Y       Z
+  ====  ======  ======  =====
+  X     -       0.226   0.165
+  Y     -1.238  -       0.658
+  Z     -1.424  -0.447  -
+  ====  ======  ======  =====
+
+------------
 
 11. Multiple linear regression
 ##############################
@@ -358,6 +368,8 @@ The `pingouin.normality` function works with lists, arrays, or pandas DataFrame 
   X           0.143  0.068   2.089   0.046  0.139     0.076       0.003        0.283
   Z          -0.069  0.167  -0.416   0.681  0.139     0.076      -0.412        0.273
   =========  ======  =====  ======  ======  =====  ========  ==========  ===========
+
+------------
 
 12. Mediation analysis
 ######################
@@ -378,6 +390,8 @@ The `pingouin.normality` function works with lists, arrays, or pandas DataFrame 
   Direct     0.143  0.068   0.046       0.003        0.283  Yes
   Indirect  -0.007  0.025   0.898      -0.069        0.029  No
   ========  ======  =====  ======  ==========  ===========  =====
+
+------------
 
 13. Contingency analysis
 ########################
@@ -435,6 +449,7 @@ The functions that are currently supported as pandas method are:
 * `pingouin.partial_corr <https://pingouin-stats.org/generated/pingouin.partial_corr.html#pingouin.partial_corr>`_
 * `pingouin.pcorr <https://pingouin-stats.org/generated/pingouin.pcorr.html#pingouin.pcorr>`_
 * `pingouin.rcorr <https://pingouin-stats.org/generated/pingouin.rcorr.html#pingouin.rcorr>`_
+* `pingouin.ptests <https://pingouin-stats.org/generated/pingouin.ptests.html#pingouin.ptests>`_
 * `pingouin.mediation_analysis <https://pingouin-stats.org/generated/pingouin.mediation_analysis.html#pingouin.mediation_analysis>`_
 
 Development

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,7 +13,7 @@ v0.6.0.dev
 
 **New functions**
 
-We have added the :py:func:`pingouin.ptests` function to calculate a T-test (T- and P-values) between all pairs of columns in a given dataframe. This is the T-test equivalent of :py:func:`pingouin.rcorr`. It can only be used as a :py:class:`pandas.DataFrame` method, not as a standalone function. The output is a square dataframe with the T-values on the lower triangle and the p-values on the upper triangle.
+We have added the :py:func:`pingouin.ptests` function to calculate a T-test (T- and p-values) between all pairs of columns in a given dataframe. This is the T-test equivalent of :py:func:`pingouin.rcorr`. It can only be used as a :py:class:`pandas.DataFrame` method, not as a standalone function. The output is a square dataframe with the T-values on the lower triangle and the p-values on the upper triangle.
 
 .. code-block:: python
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,7 +13,7 @@ v0.6.0.dev
 
 **New functions**
 
-We have added the :py:func:`pingouin.ptests` function to calculate a T-test (T- and P-values) between all pairs of columns in a given dataframe. This is the T-test equivalent of :py:func:`pingouin.rcorr`. It can only be used as a :py:class:`pingouin.DataFrame` method, not as a standalone function. The output is a square dataframe with the T-values on the lower triangle and the p-values on the upper triangle.
+We have added the :py:func:`pingouin.ptests` function to calculate a T-test (T- and P-values) between all pairs of columns in a given dataframe. This is the T-test equivalent of :py:func:`pingouin.rcorr`. It can only be used as a :py:class:`pandas.DataFrame` method, not as a standalone function. The output is a square dataframe with the T-values on the lower triangle and the p-values on the upper triangle.
 
 .. code-block:: python
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,21 @@ What's new
 
 *************
 
+v0.6.0.dev
+----------
+
+**New functions**
+
+We have added the :py:func:`pingouin.ptests` function to calculate a T-test (T- and P-values) between all pairs of columns in a given dataframe. This is the T-test equivalent of :py:func:`pingouin.rcorr`. It can only be used as a :py:class:`pingouin.DataFrame` method, not as a standalone function. The output is a square dataframe with the T-values on the lower triangle and the p-values on the upper triangle.
+
+.. code-block:: python
+
+   >>> import pingouin as pg
+   >>> df = pg.read_dataset('pairwise_corr').iloc[:30, 1:]
+   >>> df.ptests()
+
+*************
+
 v0.5.2 (June 2022)
 ------------------
 
@@ -34,6 +49,8 @@ h. Add support for `DataMatrix <https://pydatamatrix.eu/>`_ objects. `PR 286 <ht
 **Dependencies**
 
 a. Force scikit-learn<1.1.0 to avoid bug in :py:func:`pingouin.logistic_regression`. `PR 272 <https://github.com/raphaelvallat/pingouin/issues/272>`_.
+
+*************
 
 v0.5.1 (February 2022)
 ----------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -333,17 +333,27 @@ The :py:func:`pingouin.normality` function works with lists, arrays, or pandas D
   Y    Z    pearson   two-sided       30  0.020  [-0.34  0.38]    0.916   0.228    0.051
   ===  ===  ========  =============  ===  =====  =============  =======  ======  =======
 
-11.  Convert between effect sizes
-#################################
+------------
+
+11.  Pairwise T-test between columns of a dataframe
+###################################################
 
 .. code-block:: python
 
-    # Convert from Cohen's d to Hedges' g
-    pg.convert_effsize(0.4, 'cohen', 'hedges', nx=10, ny=12)
+    data.ptests(paired=True, stars=False)
 
-.. parsed-literal::
+.. table:: Pairwise T-tests, with T-values on the lower triangle and p-values on the upper triangle
+  :widths: auto
 
-    0.384
+  ====  ======  ======  =====
+  ..    X       Y       Z
+  ====  ======  ======  =====
+  X     -       0.226   0.165
+  Y     -1.238  -       0.658
+  Z     -1.424  -0.447  -
+  ====  ======  ======  =====
+
+------------
 
 12. Multiple linear regression
 ##############################
@@ -362,6 +372,8 @@ The :py:func:`pingouin.normality` function works with lists, arrays, or pandas D
   X           0.143  0.068   2.089   0.046  0.139     0.076       0.003        0.283
   Z          -0.069  0.167  -0.416   0.681  0.139     0.076      -0.412        0.273
   =========  ======  =====  ======  ======  =====  ========  ==========  ===========
+
+------------
 
 13. Mediation analysis
 ######################
@@ -382,6 +394,8 @@ The :py:func:`pingouin.normality` function works with lists, arrays, or pandas D
   Direct     0.143  0.068   0.046       0.003        0.283  Yes
   Indirect  -0.007  0.025   0.898      -0.069        0.029  No
   ========  ======  =====  ======  ==========  ===========  =====
+
+------------
 
 14. Contingency analysis
 ########################
@@ -406,6 +420,8 @@ The :py:func:`pingouin.normality` function works with lists, arrays, or pandas D
   neyman                -2.000  27.458  1.000  0.000     0.301    0.999
   ==================  ========  ======  =====  =====  ========  =======
 
+------------
+
 15. Bland-Altman plot
 #####################
 
@@ -417,6 +433,8 @@ The :py:func:`pingouin.normality` function works with lists, arrays, or pandas D
     mean, cov = [10, 11], [[1, 0.8], [0.8, 1]]
     x, y = np.random.multivariate_normal(mean, cov, 30).T
     ax = pg.plot_blandaltman(x, y)
+
+------------
 
 16. Plot achieved power of a paired T-test
 ##########################################
@@ -441,6 +459,8 @@ Plot the curve of achieved power given the effect size (Cohen d) and the sample 
     plt.ylabel('Power (1 - type II error)')
     plt.title('Achieved power of a paired T-test')
     sns.despine()
+
+------------
 
 17.  Paired plot
 ################
@@ -486,6 +506,7 @@ The functions that are currently supported as pandas method are:
 * :py:func:`pingouin.partial_corr`
 * :py:func:`pingouin.pcorr`
 * :py:func:`pingouin.rcorr`
+* :py:func:`pingouin.ptests`
 * :py:func:`pingouin.mediation_analysis`
 
 

--- a/notebooks/00_QuickStart.ipynb
+++ b/notebooks/00_QuickStart.ipynb
@@ -1002,14 +1002,14 @@
     }
    ],
    "source": [
-    "data[['X', 'Y', 'Z']].rcorr(method='spearman')"
+    "data.rcorr(method='spearman')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 10. Convert between effect sizes"
+    "## 10. Pairwise T-tests between columns of a dataframe"
    ]
   },
   {
@@ -1019,8 +1019,58 @@
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>X</th>\n",
+       "      <th>Y</th>\n",
+       "      <th>Z</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>X</th>\n",
+       "      <td>-</td>\n",
+       "      <td>0.226</td>\n",
+       "      <td>0.165</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Y</th>\n",
+       "      <td>-1.238</td>\n",
+       "      <td>-</td>\n",
+       "      <td>0.658</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Z</th>\n",
+       "      <td>-1.424</td>\n",
+       "      <td>-0.447</td>\n",
+       "      <td>-</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
       "text/plain": [
-       "0.38481012658227853"
+       "        X       Y      Z\n",
+       "X       -   0.226  0.165\n",
+       "Y  -1.238       -  0.658\n",
+       "Z  -1.424  -0.447      -"
       ]
      },
      "execution_count": 12,
@@ -1029,8 +1079,7 @@
     }
    ],
    "source": [
-    "# Convert from Cohen's d to Hedges' g\n",
-    "pg.convert_effsize(0.4, 'cohen', 'hedges', nx=10, ny=12)"
+    "data.ptests(paired=True, stars=False)"
    ]
   },
   {

--- a/notebooks/01_ANOVA.ipynb
+++ b/notebooks/01_ANOVA.ipynb
@@ -1759,7 +1759,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can now calculate a pairwise paired T-test between the three time points. The lower triangle of the dataframe contains the T-values, while the upper triangle contains the significance stars:"
+    "We can now calculate pairwise paired T-tests between the three time points. The lower triangle of the dataframe contains the T-values, while the upper triangle contains the significance stars:"
    ]
   },
   {

--- a/notebooks/01_ANOVA.ipynb
+++ b/notebooks/01_ANOVA.ipynb
@@ -1759,6 +1759,184 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "We can now calculate a pairwise paired T-test between the three time points. The lower triangle of the dataframe contains the T-values, while the upper triangle contains the significance stars:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Before</th>\n",
+       "      <th>1 week</th>\n",
+       "      <th>2 week</th>\n",
+       "      <th>3 week</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>Before</th>\n",
+       "      <td>-</td>\n",
+       "      <td></td>\n",
+       "      <td>*</td>\n",
+       "      <td>***</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1 week</th>\n",
+       "      <td>0.351</td>\n",
+       "      <td>-</td>\n",
+       "      <td></td>\n",
+       "      <td>*</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2 week</th>\n",
+       "      <td>-2.999</td>\n",
+       "      <td>-1.994</td>\n",
+       "      <td>-</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3 week</th>\n",
+       "      <td>-5.308</td>\n",
+       "      <td>-2.711</td>\n",
+       "      <td>-0.924</td>\n",
+       "      <td>-</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        Before  1 week  2 week 3 week\n",
+       "Before       -               *    ***\n",
+       "1 week   0.351       -              *\n",
+       "2 week  -2.999  -1.994       -       \n",
+       "3 week  -5.308  -2.711  -0.924      -"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data_wide.ptests(paired=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Adjusting for multiple comparisons using the Holm-Bonferroni method, and showing the p-values instead of stars:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Before</th>\n",
+       "      <th>1 week</th>\n",
+       "      <th>2 week</th>\n",
+       "      <th>3 week</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>Before</th>\n",
+       "      <td>-</td>\n",
+       "      <td>0.759</td>\n",
+       "      <td>0.075</td>\n",
+       "      <td>0.004</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1 week</th>\n",
+       "      <td>0.351</td>\n",
+       "      <td>-</td>\n",
+       "      <td>0.222</td>\n",
+       "      <td>0.096</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2 week</th>\n",
+       "      <td>-2.999</td>\n",
+       "      <td>-1.994</td>\n",
+       "      <td>-</td>\n",
+       "      <td>0.759</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3 week</th>\n",
+       "      <td>-5.308</td>\n",
+       "      <td>-2.711</td>\n",
+       "      <td>-0.924</td>\n",
+       "      <td>-</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        Before  1 week  2 week 3 week\n",
+       "Before       -   0.759   0.075  0.004\n",
+       "1 week   0.351       -   0.222  0.096\n",
+       "2 week  -2.999  -1.994       -  0.759\n",
+       "3 week  -5.308  -2.711  -0.924      -"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data_wide.ptests(paired=True, padjust=\"holm\", stars=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "***\n",
     "\n",
     "## Mixed ANOVA\n",
@@ -1770,7 +1948,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -1849,7 +2027,7 @@
        "4   4.537  2010        4  Men"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1861,7 +2039,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -1883,7 +2061,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -1966,7 +2144,7 @@
        "2  Interaction   2.106    2   36   1.053   1.162  3.242e-01  0.061    NaN"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1977,7 +2155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -2060,7 +2238,7 @@
        "2  Interaction   2.106    2   36   1.053   1.162  3.242e-01  0.041    NaN"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2079,7 +2257,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -2247,7 +2425,7 @@
        "6  8.677e-01     0.401  -0.072  "
       ]
      },
-     "execution_count": 24,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2265,7 +2443,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -2484,7 +2662,7 @@
        "9  1.772e-02     3.934   1.071  "
       ]
      },
-     "execution_count": 25,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/pingouin/pairwise.py
+++ b/pingouin/pairwise.py
@@ -715,6 +715,7 @@ def ptests(
     from numpy import triu_indices_from as tif
     from numpy import format_float_positional as ffp
     from scipy.stats import ttest_ind, ttest_rel
+
     assert isinstance(pval_stars, dict), "pval_stars must be a dictionnary."
     assert isinstance(decimals, int), "decimals must be an int."
 

--- a/pingouin/pairwise.py
+++ b/pingouin/pairwise.py
@@ -15,6 +15,7 @@ import warnings
 __all__ = [
     "pairwise_ttests",
     "pairwise_tests",
+    "ptests",
     "pairwise_tukey",
     "pairwise_gameshowell",
     "pairwise_corr",
@@ -591,6 +592,164 @@ def pairwise_tests(
         stats.rename(columns={"Time": factors[0]}, inplace=True)
 
     return _postprocess_dataframe(stats)
+
+
+@pf.register_dataframe_method
+def ptests(
+    self,
+    paired=False,
+    decimals=3,
+    padjust=None,
+    stars=True,
+    pval_stars={0.001: "***", 0.01: "**", 0.05: "*"},
+    **kwargs
+):
+    """
+    Pairwise T-test between columns of a dataframe.
+
+    T-values are reported on the lower triangle of the output pairwise matrix and p-values on the
+    upper triangle. This method is a faster, but less exhaustive, matrix-version of the
+    :py:func:`pingouin.pairwise_test` function. Missing values are automatically removed from each
+    pairwise T-test.
+
+    Parameters
+    ----------
+    self : :py:class:`pandas.DataFrame`
+        Input dataframe.
+    paired : boolean
+        Specify whether the two observations are related (i.e. repeated measures) or independent.
+    decimals : int
+        Number of decimals to display in the output matrix.
+    padjust : string or None
+        P-values adjustment for multiple comparison
+
+        * ``'none'``: no correction
+        * ``'bonf'``: one-step Bonferroni correction
+        * ``'sidak'``: one-step Sidak correction
+        * ``'holm'``: step-down method using Bonferroni adjustments
+        * ``'fdr_bh'``: Benjamini/Hochberg FDR correction
+        * ``'fdr_by'``: Benjamini/Yekutieli FDR correction
+    stars : boolean
+        If True, only significant p-values are displayed as stars using the pre-defined thresholds
+        of ``pval_stars``. If False, all the raw p-values are displayed.
+    pval_stars : dict
+        Significance thresholds. Default is 3 stars for p-values <0.001, 2 stars for
+        p-values <0.01 and 1 star for p-values <0.05.
+    **kwargs : optional
+        Optional argument(s) passed to the lower-level scipy functions, i.e.
+        :py:func:`scipy.stats.ttest_ind` for independent T-test and
+        :py:func:`scipy.stats.ttest_rel` for paired T-test.
+
+    Returns
+    -------
+    mat : :py:class:`pandas.DataFrame`
+        Pairwise T-test matrix, of dtype str, with T-values on the lower triangle and p-values on
+        the upper triangle.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import pandas as pd
+    >>> import pingouin as pg
+    >>> # Load an example dataset of personality dimensions
+    >>> df = pg.read_dataset('pairwise_corr').iloc[:30, 1:]
+    >>> df.columns = ["N", "E", "O", 'A', "C"]
+    >>> # Add some missing values
+    >>> df.iloc[[2, 5, 20], 2] = np.nan
+    >>> df.iloc[[1, 4, 10], 3] = np.nan
+    >>> df.head().round(2)
+          N     E     O     A     C
+    0  2.48  4.21  3.94  3.96  3.46
+    1  2.60  3.19  3.96   NaN  3.23
+    2  2.81  2.90   NaN  2.75  3.50
+    3  2.90  3.56  3.52  3.17  2.79
+    4  3.02  3.33  4.02   NaN  2.85
+
+    Independent pairwise T-tests
+
+    >>> df.ptests()
+            N       E      O      A    C
+    N       -     ***    ***    ***  ***
+    E  -8.397       -                ***
+    O  -8.135  -0.119      -         ***
+    A  -8.398   0.312  0.241      -  ***
+    C  -4.759   3.753  3.791  3.629    -
+
+    Let's compare with SciPy
+
+    >>> from scipy.stats import ttest_ind
+    >>> np.round(ttest_ind(df["N"], df["E"]), 3)
+    array([-8.397,  0.   ])
+
+    Passing custom parameters to the lower-level :py:func:`scipy.stats.ttest_ind` function
+
+    >>> df.ptests(alternative="greater", equal_var=True)
+            N       E      O      A    C
+    N       -
+    E  -8.397       -                ***
+    O  -8.135  -0.119      -         ***
+    A  -8.398   0.312  0.241      -  ***
+    C  -4.759   3.753  3.791  3.629    -
+
+    Paired T-test, showing the actual p-values instead of stars
+
+    >>> df.ptests(paired=True, stars=False, decimals=4)
+            N        E       O       A       C
+    N        -   0.0000  0.0000  0.0000  0.0002
+    E  -7.0773        -  0.8776  0.7522  0.0012
+    O  -8.0568  -0.1555       -  0.8137  0.0008
+    A  -8.3994   0.3191  0.2383       -  0.0009
+    C  -4.2511   3.5953  3.7849  3.7652       -
+
+    Adjusting for multiple comparisons using the Holm-Bonferroni method
+
+    >>> df.ptests(paired=True, stars=False, padjust="holm")
+            N       E      O      A      C
+    N       -   0.000  0.000  0.000  0.001
+    E  -7.077       -     1.     1.  0.005
+    O  -8.057  -0.155      -     1.  0.005
+    A  -8.399   0.319  0.238      -  0.005
+    C  -4.251   3.595  3.785  3.765      -
+    """
+    from numpy import triu_indices_from as tif
+    from numpy import format_float_positional as ffp
+    from scipy.stats import ttest_ind, ttest_rel
+    assert isinstance(pval_stars, dict), "pval_stars must be a dictionnary."
+    assert isinstance(decimals, int), "decimals must be an int."
+
+    if paired:
+        func = ttest_rel
+    else:
+        func = ttest_ind
+
+    # Get T-values and p-values
+    mat = self.corr(method=lambda x, y: func(x, y, **kwargs)[0]).round(decimals)
+    mat_upper = self.corr(method=lambda x, y: func(x, y, **kwargs)[1])
+
+    if padjust is not None:
+        pvals = mat_upper.to_numpy()[tif(mat, k=1)]
+        mat_upper.to_numpy()[tif(mat, k=1)] = multicomp(pvals, alpha=0.05, method=padjust)[1]
+
+    # Convert T-values to str
+    mat = mat.astype(str)
+    # Inplace modification of the diagonal
+    np.fill_diagonal(mat.to_numpy(), "-")
+
+    def replace_pval(x):
+        for key, value in pval_stars.items():
+            if x < key:
+                return value
+        return ""
+
+    if stars:
+        # Replace p-values by stars
+        mat_upper = mat_upper.applymap(replace_pval)
+    else:
+        mat_upper = mat_upper.applymap(lambda x: ffp(x, precision=decimals))
+
+    # Replace upper triangle by p-values
+    mat.to_numpy()[tif(mat, k=1)] = mat_upper.to_numpy()[tif(mat, k=1)]
+    return mat
 
 
 @pf.register_dataframe_method

--- a/pingouin/pairwise.py
+++ b/pingouin/pairwise.py
@@ -718,7 +718,7 @@ def ptests(
     from numpy import format_float_positional as ffp
     from scipy.stats import ttest_ind, ttest_rel
 
-    assert isinstance(pval_stars, dict), "pval_stars must be a dictionnary."
+    assert isinstance(pval_stars, dict), "pval_stars must be a dictionary."
     assert isinstance(decimals, int), "decimals must be an int."
 
     if paired:
@@ -728,7 +728,7 @@ def ptests(
 
     # Get T-values and p-values
     # We cannot use pandas.DataFrame.corr here because it will incorrectly remove rows missing
-    # values, even when using an independet T-test!
+    # values, even when using an independent T-test!
     cols = self.columns
     combs = list(combinations(cols, 2))
     mat = pd.DataFrame(columns=cols, index=cols, dtype=np.float64)

--- a/pingouin/pairwise.py
+++ b/pingouin/pairwise.py
@@ -612,6 +612,8 @@ def ptests(
     :py:func:`pingouin.pairwise_test` function. Missing values are automatically removed from each
     pairwise T-test.
 
+    .. versionadded:: 0.6.0
+
     Parameters
     ----------
     self : :py:class:`pandas.DataFrame`

--- a/pingouin/tests/test_pairwise.py
+++ b/pingouin/tests/test_pairwise.py
@@ -490,8 +490,8 @@ class TestPairwise(TestCase):
         from scipy.stats import ttest_ind, ttest_rel
 
         # Load BFI dataset
-        df = read_dataset('pairwise_corr').iloc[:30, 1:]
-        df.columns = ["N", "E", "O", 'A', "C"]
+        df = read_dataset("pairwise_corr").iloc[:30, 1:]
+        df.columns = ["N", "E", "O", "A", "C"]
         # Add some missing values
         df.iloc[[2, 5, 20], 2] = np.nan
         df.iloc[[1, 4, 10], 3] = np.nan

--- a/pingouin/tests/test_utils.py
+++ b/pingouin/tests/test_utils.py
@@ -149,10 +149,8 @@ class TestUtils(TestCase):
         assert np.allclose(y_nan, [[6.0], [3.0], [2.0]])
         # When y is None
         remove_na(x, None, paired=False)
-        # When x or y is an empty list
+        # When y is an empty list
         # See https://github.com/raphaelvallat/pingouin/issues/222
-        with pytest.raises(AssertionError):
-            remove_na(x=[], y=0)
         with pytest.raises(AssertionError):
             remove_na(x, y=[])
 


### PR DESCRIPTION
As discussed in https://github.com/raphaelvallat/pingouin/pull/290, this PR adds the `ptests` (pairwise_ttest) method to pandas.DataFrame to calculate pairwise T-tests between columns of a pandas DataFrame. This can be used as an alternative to the `pingouin.pairwise_tests` function when the data is in wide-format instead of long-format. Unlike the pairwise_tests function, the `ptests` function only return the T-values (lower triangle) and p-values (upper triangle). Please see examples below:

I'm looking for one reviewer to review the PR. Thanks!


```python
>>> import numpy as np
>>> import pandas as pd
>>> import pingouin as pg
>>> # Load an example dataset of personality dimensions
>>> df = pg.read_dataset('pairwise_corr').iloc[:30, 1:]
>>> df.columns = ["N", "E", "O", 'A', "C"]
>>> # Add some missing values
>>> df.iloc[[2, 5, 20], 2] = np.nan
>>> df.iloc[[1, 4, 10], 3] = np.nan
>>> df.head().round(2)
    N     E     O     A     C
0  2.48  4.21  3.94  3.96  3.46
1  2.60  3.19  3.96   NaN  3.23
2  2.81  2.90   NaN  2.75  3.50
3  2.90  3.56  3.52  3.17  2.79
4  3.02  3.33  4.02   NaN  2.85

# Independent pairwise T-tests

>>> df.ptests()
      N       E      O      A    C
N       -     ***    ***    ***  ***
E  -8.397       -                ***
O  -8.332  -0.596      -         ***
A  -8.804    0.12   0.72      -  ***
C  -4.759   3.753  4.074  3.787    -

# Let's compare with SciPy

>>> from scipy.stats import ttest_ind
>>> np.round(ttest_ind(df["N"], df["E"]), 3)
array([-8.397,  0.   ])

# Passing custom parameters to the lower-level :py:func:`scipy.stats.ttest_ind` function

>>> df.ptests(alternative="greater", equal_var=True)
      N       E      O      A    C
N       -
E  -8.397       -                ***
O  -8.332  -0.596      -         ***
A  -8.804    0.12   0.72      -  ***
C  -4.759   3.753  4.074  3.787    -

# Paired T-test, showing the actual p-values instead of stars

>>> df.ptests(paired=True, stars=False, decimals=4)
      N        E       O       A       C
N        -   0.0000  0.0000  0.0000  0.0002
E  -7.0773        -  0.8776  0.7522  0.0012
O  -8.0568  -0.1555       -  0.8137  0.0008
A  -8.3994   0.3191  0.2383       -  0.0009
C  -4.2511   3.5953  3.7849  3.7652       -

# Adjusting for multiple comparisons using the Holm-Bonferroni method

>>> df.ptests(paired=True, stars=False, padjust="holm")
      N       E      O      A      C
N       -   0.000  0.000  0.000  0.001
E  -7.077       -     1.     1.  0.005
O  -8.057  -0.155      -     1.  0.005
A  -8.399   0.319  0.238      -  0.005
C  -4.251   3.595  3.785  3.765      -
```