### PR TITLE
Fix numerical stability issue in multivariate_normality

### DIFF
--- a/pingouin/multivariate.py
+++ b/pingouin/multivariate.py
@@ -112,7 +112,7 @@ def multivariate_normality(X, alpha=0.05):
 
     # Lognormal mean and variance
     pmu = np.log(np.sqrt(mu**4 / (si2 + mu**2)))
-    psi = np.sqrt(np.log((si2 + mu**2) / mu**2))
+    psi = np.sqrt(np.log1p(si2 / mu**2))
 
     # P-value
     pval = lognorm.sf(hz, psi, scale=np.exp(pmu))

--- a/pingouin/tests/test_multivariate.py
+++ b/pingouin/tests/test_multivariate.py
@@ -120,6 +120,6 @@ class TestMultivariate(TestCase):
         np.random.seed(123)
         # Test that large datasets do not produce nan
         n, p = 1000, 100
-        Z = np.random.normal(size=(n,p))
+        Z = np.random.normal(size=(n, p))
         hz, pval, normal = multivariate_normality(Z, alpha=0.05)
         assert np.isfinite(pval)

--- a/pingouin/tests/test_multivariate.py
+++ b/pingouin/tests/test_multivariate.py
@@ -115,3 +115,11 @@ class TestMultivariate(TestCase):
         data.loc[[1, 3], ["A", "B"]] = np.nan
         stats = box_m(data, dvs=["A", "B"], group="group")
         assert stats.at["box", "df"] == 3
+
+    def test_multivariate_normality_numerical_stability(self):
+        np.random.seed(123)
+        # Test that large datasets do not produce nan
+        n, p = 1000, 100
+        Z = np.random.normal(size=(n,p))
+        hz, pval, normal = multivariate_normality(Z, alpha=0.05)
+        assert np.isfinite(pval)


### PR DESCRIPTION
For large n, the lognormal variance was given by a function of log(1+x) for x very close to zero. Numpy provides the more stable function log1p(x) to address cases where 1+x = 1 in floating point representations, which would otherwise incorrectly yield log(1+x) = 0.

I added a test to check this case. The previous version of the code failed this check (giving p = nan).