### PR TITLE
Handle single-sample comparsion in pairwise_test

### DIFF
--- a/pingouin/multivariate.py
+++ b/pingouin/multivariate.py
@@ -58,7 +58,7 @@ def multivariate_normality(X, alpha=0.05):
     >>> data = pg.read_dataset('multivariate')
     >>> X = data[['Fever', 'Pressure', 'Aches']]
     >>> pg.multivariate_normality(X, alpha=.05)
-    HZResults(hz=0.540086101851555, pval=0.7173686509622385, normal=True)
+    HZResults(hz=0.540086101851555, pval=0.7173686509622386, normal=True)
     """
     from scipy.stats import lognorm
 

--- a/pingouin/parametric.py
+++ b/pingouin/parametric.py
@@ -1,5 +1,6 @@
 # Author: Raphael Vallat <raphaelvallat9@gmail.com>
 import warnings
+from collections.abc import Iterable
 import numpy as np
 import pandas as pd
 from scipy.stats import f
@@ -234,6 +235,10 @@ def ttest(x, y, paired=False, alternative="two-sided", correction="auto", r=0.70
     if ny == 1:
         # Case one sample T-test
         tval, pval = ttest_1samp(x, y, alternative=alternative)
+
+        # Some versions of scipy return an array for the t-value
+        if isinstance(tval, Iterable):
+            tval = tval[0]
         dof = nx - 1
         se = np.sqrt(x.var(ddof=1) / nx)
     if ny > 1 and paired is True:

--- a/pingouin/power.py
+++ b/pingouin/power.py
@@ -455,7 +455,7 @@ def power_anova(eta_squared=None, k=None, n=None, power=None, alpha=0.05):
     3. Compute required sample size
 
     >>> print('n: %.4f' % power_anova(eta_squared=0.1, k=3, power=0.80))
-    n: 29.9255
+    n: 29.9256
 
     4. Compute achieved effect size
 

--- a/pingouin/tests/test_multivariate.py
+++ b/pingouin/tests/test_multivariate.py
@@ -117,6 +117,7 @@ class TestMultivariate(TestCase):
         assert stats.at["box", "df"] == 3
 
     def test_multivariate_normality_numerical_stability(self):
+        """Test numerical stability of multivariate_normality."""
         np.random.seed(123)
         # Test that large datasets do not produce nan
         n, p = 1000, 100

--- a/pingouin/tests/test_power.py
+++ b/pingouin/tests/test_power.py
@@ -193,7 +193,8 @@ class TestPower(TestCase):
         )
         assert np.isclose(
             power_rm_anova(eta_squared=eta2, m=2, n=100, power=0.95, corr=0.6, alpha=None),
-            0.0001797, rtol=1e-4
+            0.0001797,
+            rtol=1e-4,
         )
 
         # Error

--- a/pingouin/tests/test_power.py
+++ b/pingouin/tests/test_power.py
@@ -20,19 +20,19 @@ class TestPower(TestCase):
         """
         # ONE-SAMPLE / PAIRED
         # Alternative = 'greater'
-        assert np.allclose(
+        assert np.isclose(
             power_ttest(d=0.5, n=20, contrast="one-sample", alternative="greater"), 0.6951493
         )
-        assert np.allclose(
+        assert np.isclose(
             power_ttest(d=0.5, n=20, contrast="paired", alternative="greater"), 0.6951493
         )
-        assert np.allclose(
+        assert np.isclose(
             power_ttest(d=0.5, power=0.80, contrast="one-sample", alternative="greater"), 26.13753
         )
-        assert np.allclose(
+        assert np.isclose(
             power_ttest(n=20, power=0.80, contrast="one-sample", alternative="greater"), 0.5769185
         )
-        assert np.allclose(
+        assert np.isclose(
             power_ttest(
                 d=0.5, n=20, power=0.80, alpha=None, alternative="greater", contrast="one-sample"
             ),
@@ -40,22 +40,22 @@ class TestPower(TestCase):
             rtol=1e-03,
         )
         # Alternative = 'less'
-        assert np.allclose(
+        assert np.isclose(
             power_ttest(d=0.5, n=20, contrast="one-sample", alternative="less"), 7.083752e-05
         )
-        assert np.allclose(
+        assert np.isclose(
             power_ttest(d=-0.5, n=20, contrast="one-sample", alternative="less"), 0.6951493
         )
-        assert np.allclose(
+        assert np.isclose(
             power_ttest(d=0.5, n=20, contrast="paired", alternative="less"), 7.083752e-05
         )
-        assert np.allclose(
+        assert np.isclose(
             power_ttest(d=-0.5, power=0.80, contrast="one-sample", alternative="less"), 26.13753
         )
-        assert np.allclose(
+        assert np.isclose(
             power_ttest(n=20, power=0.80, contrast="one-sample", alternative="less"), -0.5769185
         )
-        assert np.allclose(
+        assert np.isclose(
             power_ttest(
                 d=-0.5, n=20, power=0.80, alpha=None, alternative="less", contrast="one-sample"
             ),
@@ -63,10 +63,10 @@ class TestPower(TestCase):
             rtol=1e-03,
         )
         # Two-sided
-        assert np.allclose(power_ttest(d=0.5, n=20, contrast="one-sample"), 0.5645044, rtol=1e-03)
-        assert np.allclose(power_ttest(d=0.5, power=0.80, contrast="one-sample"), 33.36713)
-        assert np.allclose(power_ttest(n=20, power=0.80, contrast="one-sample"), 0.6604413)
-        assert np.allclose(
+        assert np.isclose(power_ttest(d=0.5, n=20, contrast="one-sample"), 0.5645044, rtol=1e-03)
+        assert np.isclose(power_ttest(d=0.5, power=0.80, contrast="one-sample"), 33.36713)
+        assert np.isclose(power_ttest(n=20, power=0.80, contrast="one-sample"), 0.6604413)
+        assert np.isclose(
             power_ttest(d=0.5, n=20, power=0.80, alpha=None, contrast="one-sample"),
             0.1798043,
             rtol=1e-02,
@@ -74,28 +74,28 @@ class TestPower(TestCase):
 
         # TWO-SAMPLES
         # Alternative = 'greater'
-        assert np.allclose(power_ttest(d=0.5, n=20, alternative="greater"), 0.4633743)
-        assert np.allclose(power_ttest(d=0.5, power=0.80, alternative="greater"), 50.1508)
-        assert np.allclose(power_ttest(n=20, power=0.80, alternative="greater"), 0.8006879)
-        assert np.allclose(
+        assert np.isclose(power_ttest(d=0.5, n=20, alternative="greater"), 0.4633743)
+        assert np.isclose(power_ttest(d=0.5, power=0.80, alternative="greater"), 50.1508)
+        assert np.isclose(power_ttest(n=20, power=0.80, alternative="greater"), 0.8006879)
+        assert np.isclose(
             power_ttest(d=0.5, n=20, power=0.80, alpha=None, alternative="greater"),
             0.2315111,
             rtol=1e-01,
         )
         # Alternative = 'less'
-        assert np.allclose(power_ttest(d=-0.5, n=20, alternative="less"), 0.4633743)
-        assert np.allclose(power_ttest(d=-0.5, power=0.80, alternative="less"), 50.1508)
-        assert np.allclose(power_ttest(n=20, power=0.80, alternative="less"), -0.8006879)
-        assert np.allclose(
+        assert np.isclose(power_ttest(d=-0.5, n=20, alternative="less"), 0.4633743)
+        assert np.isclose(power_ttest(d=-0.5, power=0.80, alternative="less"), 50.1508)
+        assert np.isclose(power_ttest(n=20, power=0.80, alternative="less"), -0.8006879)
+        assert np.isclose(
             power_ttest(d=-0.5, n=20, power=0.80, alpha=None, alternative="less"),
             0.2315111,
             rtol=1e-01,
         )
         # Two-sided
-        assert np.allclose(power_ttest(d=0.5, n=20), 0.337939, rtol=1e-03)
-        assert np.allclose(power_ttest(d=0.5, power=0.80), 63.76561)
-        assert np.allclose(power_ttest(n=20, power=0.80), 0.9091587, rtol=1e-03)
-        assert np.allclose(power_ttest(d=0.5, n=20, power=0.80, alpha=None), 0.4430163, rtol=1e-01)
+        assert np.isclose(power_ttest(d=0.5, n=20), 0.337939, rtol=1e-03)
+        assert np.isclose(power_ttest(d=0.5, power=0.80), 63.76561)
+        assert np.isclose(power_ttest(n=20, power=0.80), 0.9091587, rtol=1e-03)
+        assert np.isclose(power_ttest(d=0.5, n=20, power=0.80, alpha=None), 0.4430163, rtol=1e-01)
         # Error
         with pytest.raises(ValueError):
             power_ttest(d=0.5)
@@ -106,28 +106,26 @@ class TestPower(TestCase):
         """
         # TWO-SAMPLES
         # alternative = 'greater'
-        assert np.allclose(power_ttest2n(nx=20, ny=18, d=0.5, alternative="greater"), 0.4463552)
-        assert np.allclose(
-            power_ttest2n(nx=20, ny=18, power=0.80, alternative="greater"), 0.8234684
-        )
-        assert np.allclose(
+        assert np.isclose(power_ttest2n(nx=20, ny=18, d=0.5, alternative="greater"), 0.4463552)
+        assert np.isclose(power_ttest2n(nx=20, ny=18, power=0.80, alternative="greater"), 0.8234684)
+        assert np.isclose(
             power_ttest2n(nx=20, ny=18, d=0.5, power=0.80, alpha=None, alternative="greater"),
             0.2444025,
             rtol=1e-01,
         )
         # alternative = 'less'
-        assert np.allclose(power_ttest2n(nx=20, ny=18, d=0.5, alternative="less"), 0.0008011104)
-        assert np.allclose(power_ttest2n(nx=20, ny=18, d=-0.5, alternative="less"), 0.4463552)
-        assert np.allclose(power_ttest2n(nx=20, ny=18, power=0.80, alternative="less"), -0.8234684)
-        assert np.allclose(
+        assert np.isclose(power_ttest2n(nx=20, ny=18, d=0.5, alternative="less"), 0.0008011104)
+        assert np.isclose(power_ttest2n(nx=20, ny=18, d=-0.5, alternative="less"), 0.4463552)
+        assert np.isclose(power_ttest2n(nx=20, ny=18, power=0.80, alternative="less"), -0.8234684)
+        assert np.isclose(
             power_ttest2n(nx=20, ny=18, d=0.5, power=0.80, alpha=None, alternative="less"),
             0.989896,
             rtol=1e-01,
         )
         # Two-sided
-        assert np.allclose(power_ttest2n(nx=20, ny=18, d=0.5), 0.3223224, rtol=1e-03)
-        assert np.allclose(power_ttest2n(nx=20, ny=18, power=0.80), 0.9354168)
-        assert np.allclose(
+        assert np.isclose(power_ttest2n(nx=20, ny=18, d=0.5), 0.3223224, rtol=1e-03)
+        assert np.isclose(power_ttest2n(nx=20, ny=18, power=0.80), 0.9354168)
+        assert np.isclose(
             power_ttest2n(nx=20, ny=18, d=0.5, power=0.80, alpha=None), 0.46372, rtol=1e-01
         )
         # Error
@@ -139,11 +137,11 @@ class TestPower(TestCase):
         Values are compared to the pwr R package.
         """
         eta = 0.0727003
-        assert np.allclose(power_anova(eta_squared=eta, k=4, n=20), 0.5149793)
-        assert np.allclose(power_anova(eta_squared=eta, n=20, power=0.80), 10.70313)
-        assert np.allclose(power_anova(eta_squared=eta, k=4, power=0.80), 35.75789)
-        assert np.allclose(power_anova(k=4, n=20, power=0.80, alpha=0.05), 0.1254838, rtol=1e-03)
-        assert np.allclose(
+        assert np.isclose(power_anova(eta_squared=eta, k=4, n=20), 0.5149793)
+        assert np.isclose(power_anova(eta_squared=eta, n=20, power=0.80), 10.70313)
+        assert np.isclose(power_anova(eta_squared=eta, k=4, power=0.80), 35.75789)
+        assert np.isclose(power_anova(k=4, n=20, power=0.80, alpha=0.05), 0.1254838, rtol=1e-03)
+        assert np.isclose(
             power_anova(eta_squared=eta, k=4, n=20, power=0.80, alpha=None), 0.2268337
         )
         # Error
@@ -158,23 +156,25 @@ class TestPower(TestCase):
         eta2 = 0.058823529411764705  # f = 0.25 (default in GPower)
 
         # Power
-        assert np.allclose(
+        assert np.isclose(
             power_rm_anova(eta_squared=eta, m=4, n=20, epsilon=1, corr=0.5), 0.9998070
         )
-        assert np.allclose(
+        assert np.isclose(
             power_rm_anova(eta_squared=eta, m=3, n=20, epsilon=0.9, corr=0.5), 0.9968277
         )
-        assert np.allclose(
+        assert np.isclose(
             power_rm_anova(eta_squared=eta2, m=3, n=10, epsilon=1, corr=0.7), 0.5271828
         )
-        assert np.allclose(
+        assert np.isclose(
             power_rm_anova(eta_squared=eta2, m=2, n=18, epsilon=1, corr=0.6), 0.6089353
         )
-        assert np.allclose(power_rm_anova(eta_squared=eta2, m=3, n=10, corr=-0.5), 0.13818)
+        assert np.isclose(
+            power_rm_anova(eta_squared=eta2, m=3, n=10, corr=-0.5), 0.13818, rtol=1e-4
+        )
 
         # Number of repeated measures
-        assert np.allclose(power_rm_anova(eta_squared=eta2, n=30, power=0.9), 3.9274700428)
-        assert np.allclose(power_rm_anova(eta_squared=eta2, n=20, power=0.8), 5.129210021)
+        assert np.isclose(power_rm_anova(eta_squared=eta2, n=30, power=0.9), 3.9274700428)
+        assert np.isclose(power_rm_anova(eta_squared=eta2, n=20, power=0.8), 5.129210021)
 
         # Sample size
         assert np.ceil(power_rm_anova(eta_squared=eta, m=3, power=0.80)) == 9
@@ -183,17 +183,17 @@ class TestPower(TestCase):
         assert np.ceil(power_rm_anova(eta2, 3, power=0.90, epsilon=0.9)) == 39
 
         # Effect size (eta-square)
-        assert np.allclose(power_rm_anova(n=20, m=3, power=0.80), 0.0800112)
-        assert np.allclose(power_rm_anova(n=20, m=2, power=0.90), 0.12747503)
-        assert np.allclose(power_rm_anova(n=50, m=4, power=0.95, corr=0.7), 0.02576957)
+        assert np.isclose(power_rm_anova(n=20, m=3, power=0.80), 0.0800112)
+        assert np.isclose(power_rm_anova(n=20, m=2, power=0.90), 0.12747503)
+        assert np.isclose(power_rm_anova(n=50, m=4, power=0.95, corr=0.7), 0.02576957)
 
         # Alpha
-        assert np.allclose(
+        assert np.isclose(
             power_rm_anova(eta_squared=eta, m=3, n=50, power=0.95, alpha=None), 3.652063e-9
         )
-        assert np.allclose(
+        assert np.isclose(
             power_rm_anova(eta_squared=eta2, m=2, n=100, power=0.95, corr=0.6, alpha=None),
-            0.0001797,
+            0.0001797, rtol=1e-4
         )
 
         # Error
@@ -205,23 +205,23 @@ class TestPower(TestCase):
         Values are compared to the pwr R package.
         """
         # Two-sided
-        assert np.allclose(power_corr(r=0.5, n=20), 0.6378746)
-        assert np.allclose(power_corr(r=0.5, power=0.80), 28.24841)
-        assert np.allclose(power_corr(n=20, power=0.80), 0.5821478)
-        assert np.allclose(power_corr(r=0.5, n=20, power=0.80, alpha=None), 0.1377332, rtol=1e-03)
+        assert np.isclose(power_corr(r=0.5, n=20), 0.6378746)
+        assert np.isclose(power_corr(r=0.5, power=0.80), 28.24841)
+        assert np.isclose(power_corr(n=20, power=0.80), 0.5821478)
+        assert np.isclose(power_corr(r=0.5, n=20, power=0.80, alpha=None), 0.1377332, rtol=1e-03)
 
         # Greater
-        assert np.allclose(power_corr(r=0.5, n=20, alternative="greater"), 0.7509873)
-        assert np.allclose(power_corr(r=-0.1, n=20, alternative="greater"), 0.01941224)
-        assert np.allclose(power_corr(r=0.5, power=0.80, alternative="greater"), 22.60907)
-        assert np.allclose(power_corr(n=20, power=0.80, alternative="greater"), 0.5286949)
+        assert np.isclose(power_corr(r=0.5, n=20, alternative="greater"), 0.7509873)
+        assert np.isclose(power_corr(r=-0.1, n=20, alternative="greater"), 0.01941224)
+        assert np.isclose(power_corr(r=0.5, power=0.80, alternative="greater"), 22.60907)
+        assert np.isclose(power_corr(n=20, power=0.80, alternative="greater"), 0.5286949)
 
         # Less
-        assert np.allclose(power_corr(r=-0.5, n=20, alternative="less"), 0.7509873)
-        assert np.allclose(power_corr(r=-0.1, n=20, alternative="less"), 0.1118106)
-        assert np.allclose(power_corr(r=0.1, n=20, alternative="less"), 0.01941224)
-        assert np.allclose(power_corr(r=-0.5, power=0.80, alternative="less"), 22.60907)
-        assert np.allclose(power_corr(n=20, power=0.80, alternative="less"), -0.5286949)
+        assert np.isclose(power_corr(r=-0.5, n=20, alternative="less"), 0.7509873)
+        assert np.isclose(power_corr(r=-0.1, n=20, alternative="less"), 0.1118106)
+        assert np.isclose(power_corr(r=0.1, n=20, alternative="less"), 0.01941224)
+        assert np.isclose(power_corr(r=-0.5, power=0.80, alternative="less"), 22.60907)
+        assert np.isclose(power_corr(n=20, power=0.80, alternative="less"), -0.5286949)
 
         # Error & Warning
         with pytest.raises(ValueError):
@@ -236,16 +236,16 @@ class TestPower(TestCase):
         """
         w = 0.30
         # Power
-        assert np.allclose(power_chi2(dof=1, w=0.3, n=20), 0.2686618)
-        assert np.allclose(power_chi2(dof=2, w=0.3, n=100), 0.7706831)
+        assert np.isclose(power_chi2(dof=1, w=0.3, n=20), 0.2686618)
+        assert np.isclose(power_chi2(dof=2, w=0.3, n=100), 0.7706831)
         # Sample size
-        assert np.allclose(power_chi2(dof=1, w=0.3, power=0.80), 87.20954)
-        assert np.allclose(power_chi2(dof=3, w=0.3, power=0.80), 121.1396)
+        assert np.isclose(power_chi2(dof=1, w=0.3, power=0.80), 87.20954)
+        assert np.isclose(power_chi2(dof=3, w=0.3, power=0.80), 121.1396)
         # Effect size
-        assert np.allclose(power_chi2(dof=4, n=50, power=0.80), 0.4885751)
-        assert np.allclose(power_chi2(dof=1, n=50, power=0.80), 0.3962023)
+        assert np.isclose(power_chi2(dof=4, n=50, power=0.80), 0.4885751)
+        assert np.isclose(power_chi2(dof=1, n=50, power=0.80), 0.3962023)
         # Alpha
-        assert np.allclose(
+        assert np.isclose(
             power_chi2(dof=1, w=0.3, n=100, power=0.80, alpha=None), 0.03089736, atol=1e-03
         )
         # Error


### PR DESCRIPTION
Due to a scipy interface change the pairwise_test can fail when obtaining the t-value from a single sample comparison, this, I believe, fixes that issue.