### PR TITLE
Change TestRegression class test methods to fix victim flakiness

### DIFF
--- a/pingouin/tests/test_regression.py
+++ b/pingouin/tests/test_regression.py
@@ -252,6 +252,8 @@ class TestRegression(TestCase):
     def test_logistic_regression(self):
         """Test function logistic_regression."""
         # Simple regression
+        df = read_dataset("mediation")
+        df["Zero"], df["One"] = 0, 1
         lom = logistic_regression(df["X"], df["Ybin"], as_dataframe=False)
         # Compare to R
         # Reproduce in jupyter notebook with rpy2 using
@@ -359,6 +361,8 @@ class TestRegression(TestCase):
 
     def test_mediation_analysis(self):
         """Test function mediation_analysis."""
+        df = read_dataset("mediation")
+        df["Zero"], df["One"] = 0, 1
         ma = mediation_analysis(data=df, x="X", m="M", y="Y", n_boot=500)
 
         # Compare against R package mediation


### PR DESCRIPTION
When using the [`pytest-flakefinder`](https://github.com/dropbox/pytest-flakefinder) plugin with the TestRegression module, it fails. To reproduce, run:

`pytest --flake-finder --flake-runs=2 -rP pingouin/tests/test_regression.py::TestRegression`

For context, the flakefinder plugin runs the tests multiple times in a different order each time. This helps us check how robust the tests are. In this case, the tests failed because the two test modules inside `TestRegression`, `test_logistic_regression` and `test_mediation_analysis` were victim tests (defined as per [iFixFlakies](https://mir.cs.illinois.edu/winglam/publications/2019/ShiETAL19iFixFlakies.pdf)). The first test, `test_linear_regression`, was polluting the `df` variable.

More specifically, at least for the `test_logistic_regression` test, the `Ybin` column was getting populated with a single `2` value, when it is supposed to contain only `0`s and `1`s (as per [mediation.csv](https://github.com/raphaelvallat/pingouin/blob/master/pingouin/datasets/mediation.csv)). Re-initializing `df` variable in each test seems to fix this problem. The entire module runs fine if the tests are run in the current order as they are written in, but fails if run in any other order.

Since the tests access the same data, I thought of using pytest namespaces and pytest fixtures to make the code changes less repetitive but that would involve a lot of variable name changes, so this is just a quick and reliable fix for you to consider.