### PR TITLE
Add aesthetic flexibility to plot_rm_corr

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,10 @@ We have added the :py:func:`pingouin.ptests` function to calculate a T-test (T- 
    >>> df = pg.read_dataset('pairwise_corr').iloc[:30, 1:]
    >>> df.ptests()
 
+**Improvements**
+
+Added customization options to :py:func:`pingouin.plot_rm_corr`, which now takes optional keyword arguments to pass through to py:func:`seaborn.regplot` and `seaborn.scatterplot`. `PR 312 <https://github.com/raphaelvallat/pingouin/pull/312>`_.
+
 *************
 
 v0.5.2 (June 2022)

--- a/pingouin/plotting.py
+++ b/pingouin/plotting.py
@@ -898,7 +898,14 @@ def plot_shift(
 
 
 def plot_rm_corr(
-    data=None, x=None, y=None, subject=None, legend=False, kwargs_facetgrid=dict(height=4, aspect=1)
+    data=None,
+    x=None,
+    y=None,
+    subject=None,
+    legend=False,
+    kwargs_facetgrid=dict(height=4, aspect=1),
+    kwargs_line=dict(ls="solid"),
+    kwargs_scatter=dict(marker="o"),
 ):
     """Plot a repeated measures correlation.
 
@@ -914,7 +921,11 @@ def plot_rm_corr(
         If True, add legend to plot. Legend will show all the unique values in
         ``subject``.
     kwargs_facetgrid : dict
-        Optional keyword argument passed to :py:class:`seaborn.FacetGrid`
+        Optional keyword arguments passed to :py:class:`seaborn.FacetGrid`
+    kwargs_line : dict
+        Optional keyword arguments passed to :py:class:`matplotlib.pyplot.plot`
+    kwargs_scatter : dict
+        Optional keyword arguments passed to :py:class:`matplotlib.pyplot.scatter`
 
     Returns
     -------
@@ -1006,8 +1017,8 @@ def plot_rm_corr(
 
     # Start plot
     g = sns.FacetGrid(data, hue=subject, **kwargs_facetgrid)
-    g = g.map(sns.regplot, x, "pred", scatter=False, ci=None, truncate=True)
-    g = g.map(sns.scatterplot, x, y)
+    g = g.map(sns.regplot, x, "pred", scatter=False, ci=None, truncate=True, line_kws=kwargs_line)
+    g = g.map(sns.scatterplot, x, y, **kwargs_scatter)
 
     if legend:
         g.add_legend()

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,5 @@
 pytest>=4.6
 codecov
 pytest-cov
-pytest-travis-fold
 openpyxl
 mpmath


### PR DESCRIPTION
Hi @raphaelvallat - I love the `plot_rm_corr` function and needed some flexibility to change its scatter and line features (e.g., marker size and line width). I made a simple change to allow this, adding two sets of kwargs that get passed through to seaborn. Nothing about the defaults have changed, it just offers flexibility if desired.

Sorry I didn't open an Issue first, it was just such a straight-forward change I thought I'd go for it. No pressure if you want to reject this idea.