### PR TITLE
Add axis title to plot_shift

### DIFF
--- a/pingouin/plotting.py
+++ b/pingouin/plotting.py
@@ -657,18 +657,18 @@ def plot_paired(
 
 
 def plot_shift(
-                x,
-                y,
-                paired=False,
-                n_boot=1000,
-                percentiles=np.arange(10, 100, 10),
-                confidence=0.95,
-                seed=None,
-                show_median=True,
-                violin=True,
-                title="Plot Shift",
-                x_label="X",
-                y_label="Y"                
+    x,
+    y,
+    paired=False,
+    n_boot=1000,
+    percentiles=np.arange(10, 100, 10),
+    confidence=0.95,
+    seed=None,
+    show_median=True,
+    violin=True,
+    title="Plot Shift",
+    x_label="X",
+    y_label="Y",
 ):
 
     """Shift plot.
@@ -679,7 +679,7 @@ def plot_shift(
         First and second set of observations.
     paired : bool
         Specify whether ``x`` and ``y`` are related (i.e. repeated measures) or independent.
-    
+
     .. versionadded:: 0.3.0
     n_boot : int
         Number of bootstrap iterations. The higher, the better, the slower.
@@ -695,43 +695,43 @@ def plot_shift(
     violin: boolean
         If True (default), plot the density of X and Y distributions. Defaut set to True.
     title: str
-        Define which title should be used for all plot. 
+        Define which title should be used for all plot.
             Default set "Plot Shift"
     x_label: str
-        Define which label should be used for X array. 
+        Define which label should be used for X array.
             Default set "X"
     y_label: str
-        Define which label should be used for Y array.  
-            Default set "Y"        
-    
+        Define which label should be used for Y array.
+            Default set "Y"
+
     Returns
     -------
     fig : matplotlib Figure instance
         Matplotlib Figure. To get the individual axes, use fig.axes.
-    
+
     See also
     --------
     harrelldavis
-    
+
     Notes
     -----
     The shift plot is described in [1]_. It computes a shift function [2]_ for two (in)dependent
     groups using the robust Harrell-Davis quantile estimator in conjunction with bias-corrected
     bootstrap confidence intervals.
-    
+
     References
     ----------
     .. [1] Rousselet, G. A., Pernet, C. R. and Wilcox, R. R. (2017). Beyond
            differences in means: robust graphical methods to compare two groups
            in neuroscience. Eur J Neurosci, 46: 1738-1748.
            doi:10.1111/ejn.13610
-    
+
     .. [2] https://garstats.wordpress.com/2016/07/12/shift-function/
-    
+
     Examples
     --------
     Default shift plot
-    
+
     .. plot::
         >>> import numpy as np
         >>> import pingouin as pg
@@ -739,11 +739,11 @@ def plot_shift(
         >>> x = np.random.normal(5.5, 2, 50)
         >>> y = np.random.normal(6, 1.5, 50)
         >>> fig = pg.plot_shift(x, y)
-    
+
     With different options
-    
+
     .. plot::
-    
+
         >>> import numpy as np
         >>> import pingouin as pg
         >>> np.random.seed(42)
@@ -777,7 +777,7 @@ def plot_shift(
     delta = y_per - x_per
 
     # Compute bootstrap distribution of differences
-    rng = np.random.RandomState(seed) 
+    rng = np.random.RandomState(seed)
     if paired:
         bootsam = rng.choice(np.arange(nx), size=(nx, n_boot), replace=True)
         bootstat = hd(y[bootsam], percentiles, axis=0) - hd(x[bootsam], percentiles, axis=0)
@@ -881,42 +881,46 @@ def plot_shift(
     #######################
     # Main title
     #######################
-    ax1.set_title(title,color="#616161")
-    
+    ax1.set_title(title, color="#616161")
+
     #######################
     # Entitled for labels
     #######################
-    #x_patch = mpatches.Patch(color='#88bedc', label=x_label)
-    #y_patch = mpatches.Patch(color='#cfcfcf', label=y_label)
+    # x_patch = mpatches.Patch(color='#88bedc', label=x_label)
+    # y_patch = mpatches.Patch(color='#cfcfcf', label=y_label)
     colors = ["#88bedc", "#cfcfcf"]
-    
-    texts = [y_label,x_label]
-    
+
+    texts = [y_label, x_label]
+
     from matplotlib.legend_handler import HandlerPatch
+
     class HandlerEllipse(HandlerPatch):
-        def create_artists(self, legend, orig_handle,
-                        xdescent, ydescent, width, height, fontsize, trans):
+        def create_artists(
+            self, legend, orig_handle, xdescent, ydescent, width, height, fontsize, trans
+        ):
             center = 0.5 * width - 0.5 * xdescent, 0.5 * height - 0.5 * ydescent
-            p = mpatches.Ellipse(xy=center,
-                                 width=height + xdescent,
-                                 height=height + ydescent)
-                                 
+            p = mpatches.Ellipse(xy=center, width=height + xdescent, height=height + ydescent)
+
             self.update_prop(p, orig_handle, legend)
             p.set_transform(trans)
             return [p]
 
+    c = [
+        mpatches.Circle((0.1, 0.1), radius=0.25, facecolor=colors[i], edgecolor="none")
+        for i in range(len(texts))
+    ]
 
-    c = [mpatches.Circle((0.1, 0.1), radius = 0.25, facecolor=colors[i], edgecolor="none" ) for i in range(len(texts))]
+    plt.legend(
+        c,
+        texts,
+        bbox_to_anchor=(1, 0.2),
+        loc="best",
+        ncol=1,
+        prop={"size": 8},
+        handler_map={mpatches.Circle: HandlerEllipse()},
+    ).get_frame()
 
-    plt.legend(c,
-               texts,
-               bbox_to_anchor=(1, 0.2), 
-               loc='best', 
-               ncol=1,
-               prop = {'size' : 8},
-               handler_map={mpatches.Circle: HandlerEllipse()}).get_frame()
-   
-    #plt.legend(handles=[x_patch,y_patch],loc="best")
+    # plt.legend(handles=[x_patch,y_patch],loc="best")
     #######################
     # Plots quantiles shift
     #######################


### PR DESCRIPTION
The entire library is absolutely amazing; thank you for developing it. I came up with a minor improvement for the "Shift plot". No matter what data array we provide, this graphic shows X and Y. There may be disagreement about its use in academic papers. I believed that by defining X and Y, this conflict would be addressed. I created an edit for this where the user can configure the X and Y variables as well as the plot title. The labels being on the Y axis creates problems with the size of the figure, thus I located them as a legend in the plot.

I have ideas for other modules and would like to add them when I have the time. My initial contribution would be adding the odds ratio and CI-range values to the chi-sqr module.

Here my test code;
[plotting_test.zip](https://github.com/raphaelvallat/pingouin/files/10122374/plotting_test.zip)