### PR TITLE
clip r values

### DIFF
--- a/pingouin/correlation.py
+++ b/pingouin/correlation.py
@@ -637,6 +637,10 @@ def corr(x, y, alternative="two-sided", method="pearson", **kwargs):
     n_outliers = sum(outliers) if "outliers" in locals() else 0
     n_clean = n - n_outliers
 
+    # Rounding errors caused an r value marginally beyond 1
+    if abs(r) > 1 and np.isclose(abs(r), 1):
+        r = np.clip(r, -1, 1)
+
     # Compute the parametric 95% confidence interval and power
     if abs(r) == 1:
         ci = [r, r]


### PR DESCRIPTION
Fixes #340 

I added `np.clip` to `pg.corr`, right after where all the `r` values are calculated and before being passed to `power_corr`, so I think this should catch all similar cases. Rather than _always_ clipping, I only do it if the r value exceeds -1 or 1 _and_ `np.isclose` to abs(1). I don't imagine getting r values exceeding those bounds, but this felt safer to prevent accidentally clipping  something super-high down to 1.

Re-running the original code that produced the error will work now:

```python
import numpy as np
import pingouin as pg
pg.corr([1, np.nan, 2, 4], [1, 2, np.nan, 3], method='bicor')
# bicor  2  1.0  [1.0, 1.0]    NaN      1
```