### PR TITLE
Function test fails for np.mean

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
 
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     runs-on: ${{ matrix.platform }}
 

--- a/pingouin/effsize.py
+++ b/pingouin/effsize.py
@@ -356,14 +356,14 @@ def compute_bootci(
     ...       f"{bt.mean():.4f} ± {bt.std():.4f}")
     The bootstrap distribution has 10000 samples. The mean and standard 0.8807 ± 0.1704
     """
-    from inspect import isfunction
+    from inspect import isfunction, isroutine
     from scipy.stats import norm
 
     # Check other arguments
     assert isinstance(confidence, float)
     assert 0 < confidence < 1, "confidence must be between 0 and 1."
     assert method in ["norm", "normal", "percentile", "per", "cpercentile", "cper"]
-    assert isfunction(func) or isinstance(func, str), (
+    assert isfunction(func) or isinstance(func, str) or isroutine(func), (
         "func must be a function (e.g. np.mean, custom function) or a string (e.g. 'pearson'). "
         "See documentation for more details."
     )

--- a/pingouin/tests/test_effsize.py
+++ b/pingouin/tests/test_effsize.py
@@ -125,7 +125,6 @@ class TestEffsize(TestCase):
         assert ci_p[0] == 2.98 and ci_p[1] == 3.21
         assert ci_c[0] == 2.98 and round(ci_c[1], 1) == 3.2
 
-
         # 3. Univariate custom function: skewness
         from scipy.stats import skew
 

--- a/pingouin/tests/test_effsize.py
+++ b/pingouin/tests/test_effsize.py
@@ -117,6 +117,15 @@ class TestEffsize(TestCase):
         assert ci_p[0] == 2.98 and ci_p[1] == 3.21
         assert ci_c[0] == 2.98 and round(ci_c[1], 1) == 3.2
 
+        # 2.a Univariate function: np.mean
+        ci_n = compute_bootci(x_m, func=np.mean, method="norm", seed=42)
+        ci_p = compute_bootci(x_m, func=np.mean, method="per", seed=42)
+        ci_c = compute_bootci(x_m, func=np.mean, method="cper", seed=42)
+        assert ci_n[0] == 2.98 and ci_n[1] == 3.21
+        assert ci_p[0] == 2.98 and ci_p[1] == 3.21
+        assert ci_c[0] == 2.98 and round(ci_c[1], 1) == 3.2
+
+
         # 3. Univariate custom function: skewness
         from scipy.stats import skew
 


### PR DESCRIPTION
Closes #379 

Without the change, the 3.11 fails as described in issue #379 . Remaining failures are not introduced by this PR. 