### PR TITLE
Add Quade's test implementation

### DIFF
--- a/tests/test_nonparametric.py
+++ b/tests/test_nonparametric.py
@@ -249,66 +249,68 @@ class TestNonParametric(TestCase):
         """Test function quades"""
         # Basic test case
         data = {
-            'group': ['A', 'A', 'A', 'A', 'A', 'B', 'B', 'B', 'B', 'B'],
-            'pretest': [50, 60, 45, 70, 65, 55, 75, 60, 80, 70],
-            'posttest': [52, 63, 47, 72, 67, 70, 95, 85, 100, 95]
+            "group": ["A", "A", "A", "A", "A", "B", "B", "B", "B", "B"],
+            "pretest": [50, 60, 45, 70, 65, 55, 75, 60, 80, 70],
+            "posttest": [52, 63, 47, 72, 67, 70, 95, 85, 100, 95],
         }
         df = pd.DataFrame(data)
 
-        result = quades(data=df, dv='posttest', within='pretest', group='group')
+        result = quades(data=df, dv="posttest", within="pretest", group="group")
 
         # Verify results
-        assert result.loc[result['Group'] == 'A', 'F'].values[0] == '12.635'
-        assert result.loc[result['Group'] == 'A', 'p-value'].values[0] == '0.0075'
+        assert result.loc[result["Group"] == "A", "F"].values[0] == "12.635"
+        assert result.loc[result["Group"] == "A", "p-value"].values[0] == "0.0075"
 
         # Check if the output is a DataFrame and has the correct column names
         assert isinstance(result, pd.DataFrame)
-        assert 'Group' in result.columns
-        assert 'F' in result.columns
-        assert 'p-value' in result.columns
+        assert "Group" in result.columns
+        assert "F" in result.columns
+        assert "p-value" in result.columns
 
         # Additional test cases
 
         # Edge case: Empty DataFrame
-        empty_df = pd.DataFrame(columns=['group', 'pretest', 'posttest'])
+        empty_df = pd.DataFrame(columns=["group", "pretest", "posttest"])
         try:
-            quades(data=empty_df, dv='posttest', within='pretest', group='group')
+            quades(data=empty_df, dv="posttest", within="pretest", group="group")
         except ValueError:
             pass  # Expect an error for an empty DataFrame
 
         # Edge case: Only one group
-        one_group_df = pd.DataFrame({
-            'group': ['A', 'A', 'A', 'A', 'A'],
-            'pretest': [50, 60, 45, 70, 65],
-            'posttest': [52, 63, 47, 72, 67]
-        })
+        one_group_df = pd.DataFrame(
+            {
+                "group": ["A", "A", "A", "A", "A"],
+                "pretest": [50, 60, 45, 70, 65],
+                "posttest": [52, 63, 47, 72, 67],
+            }
+        )
         try:
-            quades(data=one_group_df, dv='posttest', within='pretest', group='group')
+            quades(data=one_group_df, dv="posttest", within="pretest", group="group")
         except ValueError:
             pass  # Expect an error when there is only one group
 
         # Data type validity test: Incorrect data type
         try:
-            quades(data=df, dv=123, within='pretest', group='group')
+            quades(data=df, dv=123, within="pretest", group="group")
         except TypeError:
             pass  # Expect an error when 'dv' is not a string
 
         # Test for non-existent column
         try:
-            quades(data=df, dv='nonexistent', within='pretest', group='group')
+            quades(data=df, dv="nonexistent", within="pretest", group="group")
         except KeyError:
             pass  # Expect an error when the specified column does not exist
 
         # Special case test: All 'within' values are the same
         df_same_within = df.copy()
-        df_same_within['pretest'] = 60
-        result = quades(data=df_same_within, dv='posttest', within='pretest', group='group')
+        df_same_within["pretest"] = 60
+        result = quades(data=df_same_within, dv="posttest", within="pretest", group="group")
         assert isinstance(result, pd.DataFrame)  # The result should still be a DataFrame
-        assert 'F' in result.columns and 'p-value' in result.columns
+        assert "F" in result.columns and "p-value" in result.columns
 
         # Special case test: All change scores are zero
         df_zero_change = df.copy()
-        df_zero_change['posttest'] = df_zero_change['pretest']
-        result = quades(data=df_zero_change, dv='posttest', within='pretest', group='group')
+        df_zero_change["posttest"] = df_zero_change["pretest"]
+        result = quades(data=df_zero_change, dv="posttest", within="pretest", group="group")
         assert isinstance(result, pd.DataFrame)  # The result should still be a DataFrame
-        assert 'F' in result.columns and 'p-value' in result.columns
+        assert "F" in result.columns and "p-value" in result.columns


### PR DESCRIPTION
This Pull Request implements Quade’s test in the Pingouin library, addressing the request in [Issue #134](https://github.com/raphaelvallat/pingouin/issues/134). 

Quade’s test is a non-parametric alternative to the repeated measures ANOVA, ideal for comparing multiple groups when the assumptions of normality or equal variances are violated.

Key Changes

	•	Added quades function to src/pingouin/nonparametric.py.
	•	Added unit tests for quades in tests/test_nonparametric.py.
