### PR TITLE
Fix the Github Action CI for Python tests

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -31,7 +31,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[test]
-        pip install .[docs]
 
     - name: Test with pytest
       run: |
@@ -40,6 +39,7 @@ jobs:
     - name: Build docs
       if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == 3.9 }}
       run: |
+        pip install .[docs]
         make -C docs clean
         make -C docs html
 

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -20,7 +20,7 @@ jobs:
       FORCE_COLOR: true
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -31,6 +31,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[test]
+        pip install .[docs]
 
     - name: Test with pytest
       run: |
@@ -39,7 +40,6 @@ jobs:
     - name: Build docs
       if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == 3.9 }}
       run: |
-        pip install --upgrade sphinx sphinx_bootstrap_theme numpydoc sphinx-copybutton sphinx-panels
         make -C docs clean
         make -C docs html
 

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -45,9 +45,9 @@ jobs:
 
     - name: Upload doc build artifacts
       if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == 3.9 }}
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
-        name: docs-artifact
+        name: docs-artifact-${{ matrix.platform }}-${{ matrix.python-version }}
         path: docs/build/html
 
     - name: Upload coverage report

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -47,7 +47,7 @@ jobs:
       if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == 3.9 }}
       uses: actions/upload-artifact@v4
       with:
-        name: docs-artifact-${{ matrix.platform }}-${{ matrix.python-version }}
+        name: docs-artifact
         path: docs/build/html
 
     - name: Upload coverage report

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -52,7 +52,7 @@ jobs:
 
     - name: Upload coverage report
       if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == 3.9 }}
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v4
       with:
         token: c6ed6ca6-a040-4f23-9ebf-8c474c998097
         file: ./coverage.xml

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -2,9 +2,9 @@ name: Python tests
 
 on:
   push:
-    branches: [master, develop]
+    branches: [main]
   pull_request:
-    branches: [master, develop]
+    branches: [main]
 
 jobs:
   build:

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -80,7 +80,7 @@ To inspect these build artifacts, follow these steps:
 
   Screenshot of the GitHub checks dropdown menu
 
-* Click on the check that starts with ``Python tests / build (ubuntu-latest, 3.8)``
+* Click on the check that starts with ``Python tests / build (ubuntu-latest, 3.9)``
 * Now in the top right corner of the opening window, you will see a small dropdown menu called "Artifacts"
 
 .. figure::  /pictures/github_build_artifacts.png


### PR DESCRIPTION
This PR corrects a typo in the Python tests Github Action CI yaml file that was preventing the tests from running on PRs. The pingouin master branch was recently renamed from `master` to `main`, and now the yaml file reflects that. This was identified in [a comment](https://github.com/raphaelvallat/pingouin/pull/443#issuecomment-2400153386) in #443.