### PR TITLE
Deploy docs to Github pages

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pages:
+  deploy-to-gh-pages:
     runs-on: ubuntu-24.04
     environment:
       name: documentation-github-pages

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,54 @@
+name: Deploy Documentation to Github Pages
+
+on: workflow_dispatch
+  # Alternative: trigger deployment on push
+  # push:
+  # branches: [main] 
+
+# Cancel any in-progress job or run
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pages:
+    runs-on: ubuntu-24.04
+    environment:
+      name: documentation-github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Setup python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+    - name: Enable github problem matcher
+      uses: sphinx-doc/github-problem-matcher@master
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -U pip setuptools wheel 
+        pip install .[docs]
+    - name: Sphinx build
+      run: >
+        sphinx-build
+        -b html ./docs ./docs/_builds
+        -v
+        --jobs=auto
+        --show-traceback
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        # Path to build dir, see 'sphinx run'
+        path: './docs/_builds'
+    - id: deployment
+      name: Deploy to GitHub Pages
+      uses: actions/deploy-pages@v4
+
+
+

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+pingouin.stadtfeld.xyz


### PR DESCRIPTION
Hello Raphael,

I created a Github Action to deploy the Docs to Github pages. It does not use an additional `docs` branch. This PR is more of a draft/example which deploys the docs to my custom domain ([https://pingouin.stadtfeld.xyz/](https://pingouin.stadtfeld.xyz/)). 

The following changes are needed on your site to deploy the docs to Github Pages:
1. Verify your domain to protect it. [Here](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/verifying-your-custom-domain-for-github-pages) is the official guide. 
2. Change the domain in the CNAME file to `pingouin-stats.org`. There is nothing else in this file.
3. Configure your DNS following the official guide, [Link](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site).
4. Also configure the `www` subdomain by adding the required CNAME record.

Deploying the documentation is triggered manually, because of `on: workflow_dispatch` in the `documentation.yml` file. There are [many other triggers](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows). Its possible to trigger the action if [a specific tag is used or a release created](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#running-your-workflow-only-when-a-push-of-specific-tags-occurs). I do not know what you prefer, so I went with the manual option.