### PR TITLE
Clean dependencies; add extras feature

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ test = [
     "pytest-cov",
     # Ensure coverage is new enough for `source_pkgs`.
     "coverage[toml]>=5.3",
+    "mpmath",
 ]
 docs = [
     "sphinx>7.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,28 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pingouin"
 description = "Pingouin: statistical package for Python"
+readme = "README.rst"
+license = {text = "GPL-3.0"}
 authors = [
     {name = "Raphael Vallat", email = "raphaelvallat9@gmail.com"},
 ]
+maintainers = [
+    {name = "Raphael Vallat", email = "raphaelvallat9@gmail.com"},
+]
+classifiers = [
+    "Intended Audience :: Science/Research",
+    "Operating System :: MacOS",
+    "Operating System :: POSIX",
+    "Operating System :: Unix",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Mathematics",
+]
+dynamic = ["version"]
+requires-python = ">=3.8"
 dependencies = [
     "matplotlib",
     "numpy",
@@ -19,32 +38,14 @@ dependencies = [
     "statsmodels",
     "tabulate",
 ]
-requires-python = ">=3.8"
-readme = "README.rst"
-license = {text = "GPL-3.0"}
-maintainers = [
-    {name = "Raphael Vallat", email = "raphaelvallat9@gmail.com"},
-]
-dynamic = ["version"]
-classifiers = [
-    "Intended Audience :: Science/Research",
-    "Operating System :: MacOS",
-    "Operating System :: POSIX",
-    "Operating System :: Unix",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Topic :: Scientific/Engineering :: Mathematics",
-]
 
 [project.optional-dependencies]
+extras = [
+    "mpmath",
+]
 test = [
     "pytest>=6",
     "pytest-cov",
-    "codecov",
-    "openpyxl",
-    "mpmath",
     # Ensure coverage is new enough for `source_pkgs`.
     "coverage[toml]>=5.3",
 ]


### PR DESCRIPTION
Summary:
* reorder `pyproject.toml` entries to make it easier to find the information.
* add `python 3.12` classifier
* remove `codecov`, `openpyxl` ~and `mpmath`~ test dependencies as they are not used in tests.
* add `extras` features to optionally install the `mpmath` dependency with `pip install pingouin[extras]`.

On a side note, `mpmath` is an optional dependency as it is checked if it's installed in `utils.py`.
It's also checked if `scikit-learn` and `statsmodels` are installed in `utils.py`, whereas they are part of the hard dependencies. Meaning they _should_ be installed, at least if installing with `pip`. These two dependencies could be moved to `extras` dependencies or the checks in `utils.py` could be removed.
