### PR TITLE
Update RBC calculation for Wilcoxon signed-rank test to be dependent on the alternative

### DIFF
--- a/src/pingouin/nonparametric.py
+++ b/src/pingouin/nonparametric.py
@@ -410,37 +410,37 @@ def wilcoxon(x, y=None, alternative="two-sided", **kwargs):
     >>> y = np.array([38, 37, 33, 29, 14, 12, 20, 22, 17, 25, 26, 16])
     >>> pg.wilcoxon(x, y, alternative='two-sided')
               W_val alternative     p_val       RBC      CLES
-    Wilcoxon   20.5   two-sided  0.285765 -0.378788  0.395833
+    Wilcoxon   20.5   two-sided  0.288086 -0.378788  0.395833
 
     Same but using pre-computed differences. However, the CLES effect size
     cannot be computed as it requires the raw data.
 
     >>> pg.wilcoxon(x - y)
               W_val alternative     p_val       RBC  CLES
-    Wilcoxon   20.5   two-sided  0.285765 -0.378788   NaN
+    Wilcoxon   20.5   two-sided  0.288086 -0.378788   NaN
 
     Compare with SciPy
 
     >>> import scipy
     >>> scipy.stats.wilcoxon(x, y)
-    WilcoxonResult(statistic=20.5, pvalue=0.2661660677806492)
+    WilcoxonResult(statistic=20.5, pvalue=0.2880859375)
 
     The p-value is not exactly similar to Pingouin. This is because Pingouin automatically applies
     a continuity correction. Disabling it gives the same p-value as scipy:
 
     >>> pg.wilcoxon(x, y, alternative='two-sided', correction=False)
               W_val alternative     p_val       RBC      CLES
-    Wilcoxon   20.5   two-sided  0.266166 -0.378788  0.395833
+    Wilcoxon   20.5   two-sided  0.288086 -0.378788  0.395833
 
     One-sided test
 
     >>> pg.wilcoxon(x, y, alternative='greater')
               W_val alternative     p_val       RBC      CLES
-    Wilcoxon   20.5     greater  0.876244 -0.378788  0.395833
+    Wilcoxon   20.5     greater  0.865723 -0.378788  0.395833
 
     >>> pg.wilcoxon(x, y, alternative='less')
               W_val alternative     p_val       RBC      CLES
-    Wilcoxon   20.5        less  0.142883 -0.378788  0.604167
+    Wilcoxon   20.5        less  0.144043  0.378788  0.604167
     """
     x = np.asarray(x)
     if y is not None:
@@ -490,7 +490,7 @@ def wilcoxon(x, y=None, alternative="two-sided", **kwargs):
     rsum = r.sum()
     r_plus = np.sum((d > 0) * r)
     r_minus = np.sum((d < 0) * r)
-    rbc = r_plus / rsum - r_minus / rsum
+    rbc = r_minus / rsum - r_plus / rsum if alternative == "less" else r_plus / rsum - r_minus / rsum
 
     # Fill output DataFrame
     stats = pd.DataFrame(

--- a/src/pingouin/nonparametric.py
+++ b/src/pingouin/nonparametric.py
@@ -490,7 +490,9 @@ def wilcoxon(x, y=None, alternative="two-sided", **kwargs):
     rsum = r.sum()
     r_plus = np.sum((d > 0) * r)
     r_minus = np.sum((d < 0) * r)
-    rbc = r_minus / rsum - r_plus / rsum if alternative == "less" else r_plus / rsum - r_minus / rsum
+    rbc = (
+        r_minus / rsum - r_plus / rsum if alternative == "less" else r_plus / rsum - r_minus / rsum
+    )
 
     # Fill output DataFrame
     stats = pd.DataFrame(

--- a/tests/test_nonparametric.py
+++ b/tests/test_nonparametric.py
@@ -104,7 +104,7 @@ class TestNonParametric(TestCase):
         # Note that the RBC value are compared to JASP in test_pairwise.py
         # The RBC values in JASP does not change according to the tail.
         assert round(wc_pg.at["Wilcoxon", "RBC"], 3) == -0.379
-        assert round(wc_pg_less.at["Wilcoxon", "RBC"], 3) == -0.379
+        assert round(wc_pg_less.at["Wilcoxon", "RBC"], 3) == 0.379
         assert round(wc_pg_greater.at["Wilcoxon", "RBC"], 3) == -0.379
         # CLES is compared to:
         # https://janhove.github.io/reporting/2016/11/16/common-language-effect-sizes


### PR DESCRIPTION
Closes #456 

I had a look at providing a PR, but I am unsure if I broke more than I assumed or I am misunderstanding something. If I rerun the examples from the documentation, I get some different p-values (I updated the docs with my values in this PR) and I am seeing a test failure with just slightly mismatched values in `tests/test_pairwise.py:435`:

```E       Mismatched elements: 3 / 3 (100%)
E       Max absolute difference among violations: 0.021
E       Max relative difference among violations: 0.04347826
E        ACTUAL: array([0.912, 0.96 , 0.462])
E        DESIRED: array([0.91 , 0.951, 0.483])```

I will be able to spend some more time on this in a few days, but until then I was wondering if this might be related to a setup issue from my side you can immediately spot and help me remove?