### PR TITLE
Support for array-like and pandas-like data

### DIFF
--- a/src/pingouin/correlation.py
+++ b/src/pingouin/correlation.py
@@ -830,8 +830,7 @@ def partial_corr(
         "pearson",
         "spearman",
     ], 'only "pearson" and "spearman" are supported for partial correlation.'
-    assert hasattr(data, '__dataframe__'), \
-        "Data must be compatible with DataFrame"
+    assert hasattr(data, "__dataframe__"), "Data must be compatible with DataFrame"
     assert data.shape[0] > 2, "Data must have at least 3 samples."
     if covar is not None and (x_covar is not None or y_covar is not None):
         raise ValueError("Cannot specify both covar and {x,y}_covar.")
@@ -1190,8 +1189,7 @@ def rm_corr(data=None, x=None, y=None, subject=None):
     from pingouin import ancova, power_corr
 
     # Safety checks
-    assert hasattr(data, '__dataframe__'), \
-        "Data must be compatible with DataFrame"
+    assert hasattr(data, "__dataframe__"), "Data must be compatible with DataFrame"
     assert x in data.columns, "The %s column is not in data." % x
     assert y in data.columns, "The %s column is not in data." % y
     assert data[x].dtype.kind in "bfiu", "%s must be numeric." % x

--- a/src/pingouin/distribution.py
+++ b/src/pingouin/distribution.py
@@ -207,16 +207,16 @@ def normality(data, dv=None, group=None, method="shapiro", alpha=0.05):
     Pre   0.304021  0.858979    True
     Post  1.265656  0.531088    True
     """
-    assert isinstance(data, (pd.DataFrame, pd.Series, list, np.ndarray)) \
-        or hasattr(data, '__dataframe__')
+    assert isinstance(data, (pd.DataFrame, pd.Series, list, np.ndarray)) or hasattr(
+        data, "__dataframe__"
+    )
     assert method in ["shapiro", "normaltest", "jarque_bera"]
     if isinstance(data, pd.Series):
         data = data.to_frame()
     col_names = ["W", "pval"]
     func = getattr(scipy.stats, method)
     # Check if the data is 1D array-like
-    if isinstance(data, (list, np.ndarray)) \
-            or (hasattr(data, '__array__') and data.ndim == 1):
+    if isinstance(data, (list, np.ndarray)) or (hasattr(data, "__array__") and data.ndim == 1):
         data = np.asarray(data)
         assert data.ndim == 1, "Data must be 1D."
         assert data.size > 3, "Data must have more than 3 samples."


### PR DESCRIPTION
This is a small patch that does not change any functionality or fixes issues, but rather makes Pingouin more flexible in the types of data that it accepts. Specifically, right now Pingouin does not (always) accept data that is compatible with `numpy.ndarray` or `pandas.DataFrame` when it is not exactly of that type. This patch adds some flexibility by checking whether data can be converted to an `ndarray` or `DataFrame` when it is not of those types. It seems that data-type checking happens at different places throughout the code, so I'm not sure I caught everything.

For me, the main reason to submit this PR is to make [DataMatrix 2.0](https://github.com/open-cogsci/datamatrix/tree/2.0), which is close to fully compatible with DataFrame, also fully compatible with Pingouin. With this patch it is. The DataMatrix unit tests for now still fail on GitHub, but that's because it's pulling the latest stable version of Pingouin.

All Pingouin unittests pass with this patch.