### PR TITLE
Fixes #453: _correl_pvalue does not divide by zero if r==1

### DIFF
--- a/src/pingouin/correlation.py
+++ b/src/pingouin/correlation.py
@@ -54,6 +54,9 @@ def _correl_pvalue(r, n, k=0, alternative="two-sided"):
         "less",
     ], "Alternative must be one of 'two-sided' (default), 'greater' or 'less'."
 
+    if np.isclose(r**2, 1):  # Avoid divide by zero error
+        return 0.0  # Since p value approaches 0 as r approaches 1, just return 0
+
     # Method 1: using a student T distribution
     dof = n - k - 2
     tval = r * np.sqrt(dof / (1 - r**2))

--- a/tests/test_correlation.py
+++ b/tests/test_correlation.py
@@ -115,13 +115,13 @@ class TestCorrelation(TestCase):
         stats = corr(x, x)
         assert np.isclose(stats.at["pearson", "r"], 1)
         assert np.isclose(stats.at["pearson", "power"], 1)
-        
+
         # Perfect correlation with percbend method
-        #https://github.com/raphaelvallat/pingouin/issues/453
+        # https://github.com/raphaelvallat/pingouin/issues/453
         stats = corr(x, x, method="percbend")  # calls _correl_pvalue
         assert np.isclose(stats.at["percbend", "r"], 1)
         assert np.isclose(stats.at["percbend", "p_val"], 0)
-        
+
         # When one column is a constant, the correlation is not defined
         # and Pingouin return a DataFrame full of NaN, except for ``n``
         x, y = [1, 1, 1], [1, 2, 3]

--- a/tests/test_correlation.py
+++ b/tests/test_correlation.py
@@ -115,6 +115,13 @@ class TestCorrelation(TestCase):
         stats = corr(x, x)
         assert np.isclose(stats.at["pearson", "r"], 1)
         assert np.isclose(stats.at["pearson", "power"], 1)
+        
+        # Perfect correlation with percbend method
+        #https://github.com/raphaelvallat/pingouin/issues/453
+        stats = corr(x, x, method="percbend")  # calls _correl_pvalue
+        assert np.isclose(stats.at["percbend", "r"], 1)
+        assert np.isclose(stats.at["percbend", "p_val"], 0)
+        
         # When one column is a constant, the correlation is not defined
         # and Pingouin return a DataFrame full of NaN, except for ``n``
         x, y = [1, 1, 1], [1, 2, 3]


### PR DESCRIPTION
Before this change, `_correl_pvalue` would create a division by zero warning when r==1.

Simply adding the condition near the top of the function:
```py
    if np.isclose(r**2, 1):  # Avoid divide by zero error
        return 0.0  # Since p value approaches 0 as r approaches 1, just return 0
```

Fixes this. This assumes that n >= 2 since p would be undefined if n < 2, but I did not account for this case since it seems that the function already assumes that n >= 2.

Please let me know if you want me to make any other changes.