### PR TITLE
Fix rank biserial correlation sign for Mann-Whitney U test

### DIFF
--- a/src/pingouin/nonparametric.py
+++ b/src/pingouin/nonparametric.py
@@ -299,8 +299,7 @@ def mwu(x, y, alternative="two-sided", **kwargs):
     cles = 1 - cles if alternative == "less" else cles
 
     # Effect size 2: rank biserial correlation (Wendt 1972)
-    uval_y = x.shape[0] * y.shape[0] - uval_x
-    rbc = 1 - (2 * uval_y) / diff.size  # diff.size = x.size * y.size
+    rbc = 2 * cles - 1
 
     # Fill output DataFrame
     stats = pd.DataFrame(


### PR DESCRIPTION
Changed RBC calculation from
    rbc = 1 - (2 * uval) / diff.size
to
    rbc = 2 * cles - 1

This makes RBC directional and consistent with CLES, so that RBC > 0 when x > y.