### PR TITLE
Sphericity fix with very low eigenvalues

### DIFF
--- a/src/pingouin/distribution.py
+++ b/src/pingouin/distribution.py
@@ -998,7 +998,9 @@ def sphericity(data, dv=None, within=None, subject=None, method="mauchly", alpha
         S = data.cov(numeric_only=True).to_numpy()  # NumPy, otherwise S.mean() != grandmean
         S_pop = S - S.mean(0)[:, None] - S.mean(1)[None, :] + S.mean()
         eig = np.linalg.eigvalsh(S_pop)[1:]
-        eig = eig[eig > 0.001]  # Additional check to remove very low eig
+        # Use a relative tolerance tied to machine precision
+        tol = np.finfo(float).eps * eig.max() * d
+        eig = eig[eig > tol]
         W = np.prod(eig) / (eig.sum() / d) ** d
         logW = np.log(W)
 


### PR DESCRIPTION
Fixes #478 

_To merge after #480_ 

The previous implementation removed eigenvalues using a fixed absolute threshold (> 0.001), which is scale-dependent and can discard valid, non-zero eigenvalues when the covariance matrix has small but meaningful variance. This breaks can lead to incorrect W and p-values in Mauchly's test. The new implementation uses a relative tolerance based on machine precision and matrix scale to ensure that only numerically zero eigenvalues are discarded.