### PR TITLE
Add Cochran–Mantel–Haenszel test

### DIFF
--- a/src/pingouin/contingency.py
+++ b/src/pingouin/contingency.py
@@ -505,9 +505,7 @@ def cochran_mantel_haenszel(data, x, y, stratum, correction=True):
             mh_or_den += (obs[0, 1] * obs[1, 0]) / n
 
     if np.allclose(v, 0):
-        raise ValueError(
-            "Cannot compute CMH test: no variation in stratified tables."
-        )
+        raise ValueError("Cannot compute CMH test: no variation in stratified tables.")
 
     dof = nparams
     if dof == 1 and correction:

--- a/src/pingouin/contingency.py
+++ b/src/pingouin/contingency.py
@@ -10,7 +10,12 @@ from scipy.stats.contingency import expected_freq
 from .power import power_chi2
 from .utils import _postprocess_dataframe
 
-__all__ = ["chi2_independence", "chi2_mcnemar", "dichotomous_crosstab"]
+__all__ = [
+    "chi2_independence",
+    "chi2_mcnemar",
+    "cochran_mantel_haenszel",
+    "dichotomous_crosstab",
+]
 
 
 ###############################################################################
@@ -345,6 +350,186 @@ def chi2_mcnemar(data, x, y, correction=True):
     stats = pd.DataFrame(stats, index=["mcnemar"])
 
     return observed, _postprocess_dataframe(stats)
+
+
+def cochran_mantel_haenszel(data, x, y, stratum, correction=True):
+    """
+    Performs the Cochran–Mantel–Haenszel test of independence of two
+    categorical variables, stratified by one or more control variables.
+
+    Parameters
+    ----------
+    data : :py:class:`pandas.DataFrame`
+        The dataframe containing the ocurrences for the test.
+    x, y : string
+        The variables names for the test. Must be names of columns in ``data``.
+        Pingouin computes the generalized RxCxK Cochran-Mantel-Haenszel
+        statistic with :math:`(R - 1)(C - 1)` degrees of freedom. For 2x2xK
+        tables, this corresponds to a 1 degree of freedom CMH test.
+    stratum : string or list of strings
+        The name(s) of column(s) in ``data`` containing the stratifying
+        variable(s). The test will be computed separately for each combination
+        of stratum values and then combined into a single test statistic.
+
+        .. warning:: Missing values are not allowed.
+
+    correction : bool
+        Whether to apply continuity correction (0.5) to the CMH statistic.
+
+    Returns
+    -------
+    observed : list of :py:class:`pandas.DataFrame`
+        List of observed contingency tables for each stratum level.
+    stats : :py:class:`pandas.DataFrame`
+        The test summary:
+
+        * ``'cmh'``: The CMH test statistic
+        * ``'dof'``: The degree of freedom :math:`(R - 1)(C - 1)`
+        * ``'pval'``: The p-value of the test
+        * ``'mh_oddsratio'``: The Mantel–Haenszel odds ratio estimate for
+          2x2xK tables (``NaN`` otherwise)
+
+    Notes
+    -----
+    The Cochran–Mantel–Haenszel test is used to test the association between
+    two categorical variables while controlling for one or more stratifying
+    variables.
+
+    Pingouin computes the generalized CMH statistic for RxCxK tables, which
+    follows a chi-squared distribution with :math:`(R - 1)(C - 1)` degrees of
+    freedom. For 2x2xK tables (:math:`(R - 1)(C - 1) = 1`), this reduces to the
+    scalar CMH statistic.
+
+    The Mantel–Haenszel odds ratio is computed as:
+
+    .. math::
+
+        \\text{OR}_{MH} = \\frac{\\sum_i (a_i d_i / n_i)}{\\sum_i (b_i c_i / n_i)}
+
+    where :math:`a_i, b_i, c_i, d_i` are the entries of the 2x2 table in
+    stratum :math:`i` and :math:`n_i` is the total count in stratum :math:`i`.
+
+    References
+    ----------
+    * Cochran, W. G. (1954). Some methods for strengthening the common x² tests.
+      Biometrics, 10, 417–451.
+
+    * Mantel, N., & Haenszel, W. (1959), Statistical Aspects of the Analysis of
+      Data From Retrospective Studies of Disease. Journal of the National Cancer
+      Institute, 22(4), 719–748.
+
+    Examples
+    --------
+    >>> import pingouin as pg
+    >>> data = pg.read_dataset("cochran_mantel_haenszel")
+    >>> # Expand frequency table to one row per observation
+    >>> data = data.loc[data.index.repeat(data["count"])].reset_index(drop=True)
+    >>> observed, stats = pg.cochran_mantel_haenszel(
+    ...     data, x="income", y="satisfaction", stratum="gender"
+    ... )
+    >>> stats
+               cmh  dof      pval  mh_oddsratio
+    cmh  10.200089    9  0.334531           NaN
+    """
+    # Handle stratum as either a single column or list of columns
+    if isinstance(stratum, (str, int)):
+        stratum_cols = [stratum]
+    elif isinstance(stratum, (list, tuple)):
+        stratum_cols = list(stratum)
+    else:
+        raise AssertionError("stratum must be a string, int, list, or tuple.")
+
+    # Input validation
+    assert isinstance(data, pd.DataFrame), "data must be a pandas DataFrame."
+    assert len(stratum_cols) > 0, "stratum must contain at least one column name."
+
+    columns = (x, y, *stratum_cols)
+    assert all(isinstance(column, (str, int)) for column in columns), (
+        "column names must be string or int."
+    )
+    assert all(column in data.columns for column in columns), "columns are not in dataframe."
+
+    for column in (x, y) + tuple(stratum_cols):
+        if data[column].isna().any():
+            raise ValueError("Null values are not allowed.")
+
+    # Create groups by stratum
+    if len(stratum_cols) == 1:
+        grouped = data.groupby(stratum_cols[0], sort=False)
+    else:
+        grouped = data.groupby(stratum_cols, sort=False)
+
+    n_levels_x = data[x].nunique(dropna=False)
+    n_levels_y = data[y].nunique(dropna=False)
+
+    if n_levels_x < 2 or n_levels_y < 2:
+        raise ValueError("x and y must each have at least two levels.")
+
+    observed_tables = []
+    x_levels = pd.Index(pd.unique(data[x]))
+    y_levels = pd.Index(pd.unique(data[y]))
+    nparams = (len(x_levels) - 1) * (len(y_levels) - 1)
+
+    if nparams < 1:
+        raise ValueError("x and y must each have at least two levels.")
+
+    u = np.zeros(nparams, dtype=float)
+    v = np.zeros((nparams, nparams), dtype=float)
+
+    mh_or_num = 0.0
+    mh_or_den = 0.0
+    compute_mh_or = len(x_levels) == 2 and len(y_levels) == 2
+
+    for _, group_data in grouped:
+        obs_table = pd.crosstab(group_data[x], group_data[y], dropna=False)
+        obs_table = obs_table.reindex(index=x_levels, columns=y_levels, fill_value=0)
+        observed_tables.append(obs_table)
+
+        obs = obs_table.to_numpy(dtype=float)
+        n = obs.sum()
+        if n <= 1:
+            continue
+
+        row_sum = obs.sum(axis=1)
+        col_sum = obs.sum(axis=0)
+        expected = np.outer(row_sum, col_sum) / n
+
+        u += (obs[:-1, :-1] - expected[:-1, :-1]).ravel(order="C")
+
+        a = np.diag(row_sum[:-1]) - np.outer(row_sum[:-1], row_sum[:-1]) / n
+        b = np.diag(col_sum[:-1]) - np.outer(col_sum[:-1], col_sum[:-1]) / n
+        v += np.kron(a, b) / (n - 1)
+
+        if compute_mh_or:
+            mh_or_num += (obs[0, 0] * obs[1, 1]) / n
+            mh_or_den += (obs[0, 1] * obs[1, 0]) / n
+
+    if np.allclose(v, 0):
+        raise ValueError(
+            "Cannot compute CMH test: no variation in stratified tables."
+        )
+
+    dof = nparams
+    if dof == 1 and correction:
+        chi2_cmh = (np.abs(float(u[0])) - 0.5) ** 2 / float(v[0, 0])
+    else:
+        chi2_cmh = float(u @ np.linalg.pinv(v) @ u)
+    pval = sp_chi2.sf(chi2_cmh, dof)
+
+    mh_or = np.nan
+    if compute_mh_or and mh_or_den != 0:
+        mh_or = mh_or_num / mh_or_den
+
+    stats = {
+        "cmh": chi2_cmh,
+        "dof": dof,
+        "pval": pval,
+        "mh_oddsratio": mh_or,
+    }
+
+    stats_df = pd.DataFrame(stats, index=["cmh"])
+
+    return observed_tables, _postprocess_dataframe(stats_df)
 
 
 ###############################################################################

--- a/src/pingouin/datasets/cochran_mantel_haenszel.csv
+++ b/src/pingouin/datasets/cochran_mantel_haenszel.csv
@@ -1,0 +1,33 @@
+income,satisfaction,gender,count
+<5000,Very Dissatisfied,Female,1
+5000-15000,Very Dissatisfied,Female,2
+15000-25000,Very Dissatisfied,Female,0
+>25000,Very Dissatisfied,Female,0
+<5000,A Little Satisfied,Female,3
+5000-15000,A Little Satisfied,Female,3
+15000-25000,A Little Satisfied,Female,1
+>25000,A Little Satisfied,Female,2
+<5000,Moderately Satisfied,Female,11
+5000-15000,Moderately Satisfied,Female,17
+15000-25000,Moderately Satisfied,Female,8
+>25000,Moderately Satisfied,Female,4
+<5000,Very Satisfied,Female,2
+5000-15000,Very Satisfied,Female,3
+15000-25000,Very Satisfied,Female,5
+>25000,Very Satisfied,Female,2
+<5000,Very Dissatisfied,Male,1
+5000-15000,Very Dissatisfied,Male,0
+15000-25000,Very Dissatisfied,Male,0
+>25000,Very Dissatisfied,Male,0
+<5000,A Little Satisfied,Male,1
+5000-15000,A Little Satisfied,Male,3
+15000-25000,A Little Satisfied,Male,0
+>25000,A Little Satisfied,Male,1
+<5000,Moderately Satisfied,Male,2
+5000-15000,Moderately Satisfied,Male,5
+15000-25000,Moderately Satisfied,Male,7
+>25000,Moderately Satisfied,Male,9
+<5000,Very Satisfied,Male,1
+5000-15000,Very Satisfied,Male,1
+15000-25000,Very Satisfied,Male,3
+>25000,Very Satisfied,Male,6

--- a/src/pingouin/datasets/datasets.csv
+++ b/src/pingouin/datasets/datasets.csv
@@ -9,6 +9,7 @@ blandaltman,Hypothetical data of an agreement between two methods (Method A and 
 chi2_independence,Patients' attributes and heart conditions,chi2_independence,https://archive.ics.uci.edu/ml/datasets/Heart+Disease
 chi2_mcnemar,Responses to 2 athlete's foot treatments, chi2_mcnemar, http://www.stat.purdue.edu/~tqin/system101/method/method_mcnemar_sas.htm (adapted)
 circular,Orientation tuning properties of three neurons,circular statistics,Berens 2009
+cochran_mantel_haenszel,Job satisfaction by income and gender,cochran_mantel_haenszel,Agresti 2002 Table 7.8 / R stats::mantelhaen.test example
 cochran,Energy level across three days,Cochran,www.real-statistics.com
 cronbach_alpha,Questionnaire ratings,cronbach_alpha,www.real-statistics.com
 cronbach_wide_missing,Questionnaire rating (binary) in wide format and with missing values,cronbach_alpha,www.real-statistics.com

--- a/tests/test_contingency.py
+++ b/tests/test_contingency.py
@@ -214,6 +214,28 @@ class TestContingency(TestCase):
         assert np.isclose(stats_rxc.at["cmh", "pval"], 0.3345, atol=1e-04)
         assert np.isnan(stats_rxc.at["cmh", "mh_oddsratio"])
 
+        # Comparing 2x2xK results against R (stats::mantelhaen.test)
+        # Agresti (2002) Job Satisfaction table (2x2x2):
+        #   corrected:   M^2 = 3.6286, df = 1, p = 0.0568,  MH OR = 3.271605
+        #   uncorrected: M^2 = 4.731,  df = 1, p = 0.02962, MH OR = 3.271605
+        data_agresti["income_low"] = data_agresti["income"].isin(["<5000", "5000-15000"]).astype(int)
+        data_agresti["sat_high"] = data_agresti["satisfaction"].isin(["Moderately Satisfied", "Very Satisfied"]).astype(int)
+
+        observed_list, stats = pg.cochran_mantel_haenszel(data_agresti, "income_low", "sat_high", "gender")
+        _, stats_no_correction = pg.cochran_mantel_haenszel(data_agresti, "income_low", "sat_high", "gender", correction=False)
+        assert isinstance(observed_list, list)
+        assert len(observed_list) == 2
+        assert np.isclose(stats.at["cmh", "cmh"], 3.6286, atol=1e-04)
+        assert stats.at["cmh", "dof"] == 1
+        assert np.isclose(stats.at["cmh", "pval"], 0.0568, atol=1e-04)
+        assert np.isclose(stats.at["cmh", "mh_oddsratio"], 3.271605, atol=1e-06)
+        assert np.isclose(stats_no_correction.at["cmh", "cmh"], 4.731, atol=1e-03)
+        assert stats_no_correction.at["cmh", "dof"] == 1
+        assert np.isclose(stats_no_correction.at["cmh", "pval"], 0.02962, atol=1e-04)
+        assert np.isclose(stats_no_correction.at["cmh", "mh_oddsratio"], 3.271605, atol=1e-06)
+        # The uncorrected CMH statistic should be larger than the corrected one
+        assert stats_no_correction.at["cmh", "cmh"] > stats.at["cmh", "cmh"]
+
     def test_dichotomize_series(self):
         """Test function _dichotomize_series."""
         # Integer

--- a/tests/test_contingency.py
+++ b/tests/test_contingency.py
@@ -9,6 +9,7 @@ import pingouin as pg
 
 df_ind = pg.read_dataset("chi2_independence")
 df_mcnemar = pg.read_dataset("chi2_mcnemar")
+df_cmh = pg.read_dataset("cochran_mantel_haenszel")
 
 data_ct = pd.DataFrame(
     {
@@ -153,6 +154,65 @@ class TestContingency(TestCase):
         assert np.isclose(stats.at["mcnemar", "p_exact"], 3.305e-06)
         # midp gives slightly different results
         # assert np.allclose(stats.at['mcnemar', 'p_mid'], 3.305e-06)
+
+    def test_cochran_mantel_haenszel(self):
+        """Test function cochran_mantel_haenszel."""
+        # Setup
+        np.random.seed(42)
+        n = 200
+        stratum = np.repeat([0, 1], n // 2)
+        x = np.random.binomial(1, 0.5, n)
+        y = np.random.binomial(1, 0.6, n)
+        data = pd.DataFrame({"x": x, "y": y, "stratum": stratum})
+
+        # Testing validations
+        def expect_assertion_error(*params):
+            with pytest.raises(AssertionError):
+                pg.cochran_mantel_haenszel(*params)
+
+        expect_assertion_error(1, "x", "y", "stratum")  # Not a pd.DataFrame
+        expect_assertion_error(data, x, "y", "stratum")  # Not a string
+        expect_assertion_error(data, "x", y, "stratum")  # Not a string
+        expect_assertion_error(data, "x", "z", "stratum")  # Not a column of data
+        expect_assertion_error(data, "x", "y", "invalid")  # Not a column of data
+
+        # Testing happy-day
+        pg.cochran_mantel_haenszel(data, "x", "y", "stratum")
+
+        # Testing with multiple strata
+        data["stratum2"] = np.repeat([0, 1], n // 2)
+        observed_multi, stats_multi = pg.cochran_mantel_haenszel(data, "x", "y", ["stratum", "stratum2"])
+        assert len(observed_multi) >= 1
+        assert stats_multi.shape == (1, 4)
+
+        # Testing NaN incompatibility
+        data.iloc[0, 0] = np.nan
+        with pytest.raises(ValueError):
+            pg.cochran_mantel_haenszel(data, "x", "y", "stratum")
+
+        # Testing non-binary labels are accepted in the general CMH framework
+        data = pd.DataFrame({"x": [0, 2, 0, 2, 0, 2, 0, 2], "y": [0, 1, 1, 0, 0, 1, 1, 0], "stratum": [0, 0, 0, 0, 1, 1, 1, 1]})
+        observed_nb, stats_nb = pg.cochran_mantel_haenszel(data, "x", "y", "stratum")
+        assert len(observed_nb) == 2
+        assert stats_nb.at["cmh", "dof"] == 1
+
+        # Testing perfect association across strata still yields valid CMH output
+        data = pd.DataFrame({"x": [0, 1, 0, 1, 0, 1, 0, 1], "y": [0, 1, 0, 1, 0, 1, 0, 1], "stratum": [0, 0, 0, 0, 1, 1, 1, 1]})
+        observed_perfect, stats_perfect = pg.cochran_mantel_haenszel(data, "x", "y", "stratum")
+        assert len(observed_perfect) == 2
+        assert np.isfinite(stats_perfect.at["cmh", "cmh"])
+
+        # Comparing generalized RxCxK results against R (stats::mantelhaen.test)
+        # Agresti (2002) Job Satisfaction table (4x4x2): M^2 = 10.2, df = 9, p = 0.3345
+        data_agresti = df_cmh.loc[df_cmh.index.repeat(df_cmh["count"])].reset_index(drop=True)
+        observed_rxc, stats_rxc = pg.cochran_mantel_haenszel(data_agresti, "income", "satisfaction", "gender")
+        assert isinstance(observed_rxc, list)
+        assert len(observed_rxc) == 2
+        assert observed_rxc[0].shape == (4, 4)
+        assert np.isclose(stats_rxc.at["cmh", "cmh"], 10.2, atol=1e-01)
+        assert stats_rxc.at["cmh", "dof"] == 9
+        assert np.isclose(stats_rxc.at["cmh", "pval"], 0.3345, atol=1e-04)
+        assert np.isnan(stats_rxc.at["cmh", "mh_oddsratio"])
 
     def test_dichotomize_series(self):
         """Test function _dichotomize_series."""

--- a/tests/test_contingency.py
+++ b/tests/test_contingency.py
@@ -181,7 +181,9 @@ class TestContingency(TestCase):
 
         # Testing with multiple strata
         data["stratum2"] = np.repeat([0, 1], n // 2)
-        observed_multi, stats_multi = pg.cochran_mantel_haenszel(data, "x", "y", ["stratum", "stratum2"])
+        observed_multi, stats_multi = pg.cochran_mantel_haenszel(
+            data, "x", "y", ["stratum", "stratum2"]
+        )
         assert len(observed_multi) >= 1
         assert stats_multi.shape == (1, 4)
 
@@ -191,13 +193,25 @@ class TestContingency(TestCase):
             pg.cochran_mantel_haenszel(data, "x", "y", "stratum")
 
         # Testing non-binary labels are accepted in the general CMH framework
-        data = pd.DataFrame({"x": [0, 2, 0, 2, 0, 2, 0, 2], "y": [0, 1, 1, 0, 0, 1, 1, 0], "stratum": [0, 0, 0, 0, 1, 1, 1, 1]})
+        data = pd.DataFrame(
+            {
+                "x": [0, 2, 0, 2, 0, 2, 0, 2],
+                "y": [0, 1, 1, 0, 0, 1, 1, 0],
+                "stratum": [0, 0, 0, 0, 1, 1, 1, 1],
+            }
+        )
         observed_nb, stats_nb = pg.cochran_mantel_haenszel(data, "x", "y", "stratum")
         assert len(observed_nb) == 2
         assert stats_nb.at["cmh", "dof"] == 1
 
         # Testing perfect association across strata still yields valid CMH output
-        data = pd.DataFrame({"x": [0, 1, 0, 1, 0, 1, 0, 1], "y": [0, 1, 0, 1, 0, 1, 0, 1], "stratum": [0, 0, 0, 0, 1, 1, 1, 1]})
+        data = pd.DataFrame(
+            {
+                "x": [0, 1, 0, 1, 0, 1, 0, 1],
+                "y": [0, 1, 0, 1, 0, 1, 0, 1],
+                "stratum": [0, 0, 0, 0, 1, 1, 1, 1],
+            }
+        )
         observed_perfect, stats_perfect = pg.cochran_mantel_haenszel(data, "x", "y", "stratum")
         assert len(observed_perfect) == 2
         assert np.isfinite(stats_perfect.at["cmh", "cmh"])
@@ -205,7 +219,9 @@ class TestContingency(TestCase):
         # Comparing generalized RxCxK results against R (stats::mantelhaen.test)
         # Agresti (2002) Job Satisfaction table (4x4x2): M^2 = 10.2, df = 9, p = 0.3345
         data_agresti = df_cmh.loc[df_cmh.index.repeat(df_cmh["count"])].reset_index(drop=True)
-        observed_rxc, stats_rxc = pg.cochran_mantel_haenszel(data_agresti, "income", "satisfaction", "gender")
+        observed_rxc, stats_rxc = pg.cochran_mantel_haenszel(
+            data_agresti, "income", "satisfaction", "gender"
+        )
         assert isinstance(observed_rxc, list)
         assert len(observed_rxc) == 2
         assert observed_rxc[0].shape == (4, 4)
@@ -218,11 +234,21 @@ class TestContingency(TestCase):
         # Agresti (2002) Job Satisfaction table (2x2x2):
         #   corrected:   M^2 = 3.6286, df = 1, p = 0.0568,  MH OR = 3.271605
         #   uncorrected: M^2 = 4.731,  df = 1, p = 0.02962, MH OR = 3.271605
-        data_agresti["income_low"] = data_agresti["income"].isin(["<5000", "5000-15000"]).astype(int)
-        data_agresti["sat_high"] = data_agresti["satisfaction"].isin(["Moderately Satisfied", "Very Satisfied"]).astype(int)
+        data_agresti["income_low"] = (
+            data_agresti["income"].isin(["<5000", "5000-15000"]).astype(int)
+        )
+        data_agresti["sat_high"] = (
+            data_agresti["satisfaction"]
+            .isin(["Moderately Satisfied", "Very Satisfied"])
+            .astype(int)
+        )
 
-        observed_list, stats = pg.cochran_mantel_haenszel(data_agresti, "income_low", "sat_high", "gender")
-        _, stats_no_correction = pg.cochran_mantel_haenszel(data_agresti, "income_low", "sat_high", "gender", correction=False)
+        observed_list, stats = pg.cochran_mantel_haenszel(
+            data_agresti, "income_low", "sat_high", "gender"
+        )
+        _, stats_no_correction = pg.cochran_mantel_haenszel(
+            data_agresti, "income_low", "sat_high", "gender", correction=False
+        )
         assert isinstance(observed_list, list)
         assert len(observed_list) == 2
         assert np.isclose(stats.at["cmh", "cmh"], 3.6286, atol=1e-04)


### PR DESCRIPTION
## Add Cochran–Mantel–Haenszel test

This PR introduces support for the Cochran–Mantel–Haenszel (CMH) test, along with a reference dataset and test coverage.

### What changed

* Added a new function `pingouin.cochran_mantel_haenszel` supporting:
  * standard 2x2xK CMH tests (with and without continuity correction)
  * Mantel–Haenszel odds ratio estimation
  * generalized RxCxK tables
  * multiple stratification variables
* Added a new dataset, `cochran_mantel_haenszel.csv`, containing the Agresti job satisfaction example grouped by income, satisfaction, gender, and count.
* Added tests covering:
  * input validation
  * handling of multiple strata
  * NaN rejection
  * non-binary labels in the general CMH framework
  * perfect-association edge cases
  * agreement with the dichotomized example from `stats::mantelhaen.test`
  * agreement with the generalized RxCxK example from `stats::mantelhaen.test`

### Why

The Cochran–Mantel–Haenszel test is a commonly used method for assessing conditional independence across stratified contingency tables.

### Validation

The added assertions check that the function returns the expected statistic values for the Agresti example, validated against the equivalent R code.

### Notes

The new dataset is based on Agresti (2002), Table 7.8, and matches the example used in R’s `mantelhaen.test`.