### PR TITLE
Plotting improvements

### DIFF
--- a/src/pingouin/plotting.py
+++ b/src/pingouin/plotting.py
@@ -26,7 +26,15 @@ __all__ = [
 
 
 def plot_blandaltman(
-    x, y, agreement=1.96, xaxis="mean", confidence=0.95, annotate=True, ax=None, **kwargs
+    x,
+    y,
+    agreement=1.96,
+    xaxis="mean",
+    confidence=0.95,
+    annotate=True,
+    percentage=False,
+    ax=None,
+    **kwargs,
 ):
     """
     Generate a Bland-Altman plot to compare two sets of measurements.
@@ -36,22 +44,25 @@ def plot_blandaltman(
     x, y : pd.Series, np.array, or list
         First and second measurements.
     agreement : float
-        Multiple of the standard deviation to plot agreement limits.
-        The defaults is 1.96, which corresponds to 95% confidence interval if
-        the differences are normally distributed.
+        Multiple of the standard deviation used to compute the limits of
+        agreement (LoA). The default is 1.96, which gives LoA that contain
+        approximately 95% of differences when they are normally distributed.
     xaxis : str
         Define which measurements should be used as the reference (x-axis).
         Default is to use the average of x and y ("mean"). Accepted values are
         "mean", "x" or "y".
-    confidence : float
-        If not None, plot the specified percentage confidence interval of
-        the mean and limits of agreement. The CIs of the mean difference and
-        agreement limits describe a possible error in the
-        estimate due to a sampling error. The greater the sample size,
-        the narrower the CIs will be.
+    confidence : float or None
+        If not None, plot the specified confidence interval of the mean
+        difference and limits of agreement. These bands represent sampling
+        uncertainty around the point estimates (not prediction intervals):
+        the larger the sample size, the narrower the bands. Default is 0.95.
     annotate : bool
-        If True (default), annotate the values for the mean difference
-        and agreement limits.
+        If True (default), annotate the mean difference and upper/lower limits
+        of agreement values on the right-hand side of the plot.
+    percentage : bool
+        If True, plot percentage differences relative to the mean of each
+        pair, i.e. ``(x - y) / mean(x, y) * 100``. Useful when measurement
+        variability scales with magnitude. Default is False.
     ax : matplotlib axes
         Axis on which to draw the plot.
     **kwargs : optional
@@ -84,7 +95,8 @@ def plot_blandaltman(
     The 95% limits of agreement can be unreliable estimates of the population
     parameters especially for small sample sizes so, when comparing methods
     or assessing repeatability, it is important to calculate confidence
-    intervals for the 95% limits of agreement.
+    intervals for the 95% limits of agreement. The standard error of the
+    limits of agreement is √(3s²/n), per Bland & Altman (1986) [1]_.
 
     The code is an adaptation of the
     `PyCompare <https://github.com/jaketmp/pyCompare>`_ package. The present
@@ -127,21 +139,27 @@ def plot_blandaltman(
     _scatter_kwargs = {"color": "tab:blue", "alpha": 0.8}
     _scatter_kwargs.update(kwargs)
 
-    # Calculate mean, STD and SEM of x - y
+    # Calculate differences — absolute or percentage
+    mean_xy = np.vstack((x, y)).mean(0)
+    if percentage:
+        diff = (x - y) / mean_xy * 100
+    else:
+        diff = x - y
+
+    # Calculate mean, STD and SEM of the differences
     n = x.size
     dof = n - 1
-    diff = x - y
     mean_diff = np.mean(diff)
     std_diff = np.std(diff, ddof=1)
     mean_diff_se = np.sqrt(std_diff**2 / n)
-    # Limits of agreements
+    # Limits of agreement and their SE (Bland & Altman, 1986: SE = sqrt(3s²/n))
     high = mean_diff + agreement * std_diff
     low = mean_diff - agreement * std_diff
     high_low_se = np.sqrt(3 * std_diff**2 / n)
 
     # Define x-axis
     if xaxis == "mean":
-        xval = np.vstack((x, y)).mean(0)
+        xval = mean_xy
         xlabel = f"Mean of {xname} and {yname}"
     elif xaxis == "x":
         xval = x
@@ -154,11 +172,12 @@ def plot_blandaltman(
     if ax is None:
         ax = plt.gca()
 
-    # Plot the mean diff, limits of agreement and scatter
+    # Zero line (perfect agreement), then bias and LoA
+    ax.axhline(0, color="lightgray", linestyle="solid", lw=1, zorder=0)
     ax.scatter(xval, diff, **_scatter_kwargs)
     ax.axhline(mean_diff, color="k", linestyle="-", lw=2)
-    ax.axhline(high, color="k", linestyle=":", lw=1.5)
-    ax.axhline(low, color="k", linestyle=":", lw=1.5)
+    ax.axhline(high, color="k", linestyle="--", lw=1.5)
+    ax.axhline(low, color="k", linestyle="--", lw=1.5)
 
     # Annotate values
     if annotate:
@@ -169,26 +188,42 @@ def plot_blandaltman(
         ax.text(xloc, mean_diff + offset, "Mean", ha="right", va="bottom", transform=trans)
         ax.text(xloc, mean_diff - offset, "%.2f" % mean_diff, ha="right", va="top", transform=trans)
         ax.text(
-            xloc, high + offset, "+%.2f SD" % agreement, ha="right", va="bottom", transform=trans
+            xloc,
+            high + offset,
+            f"+{agreement:.2f}\u00d7SD",
+            ha="right",
+            va="bottom",
+            transform=trans,
         )
         ax.text(xloc, high - offset, "%.2f" % high, ha="right", va="top", transform=trans)
-        ax.text(xloc, low - offset, "-%.2f SD" % agreement, ha="right", va="top", transform=trans)
+        ax.text(
+            xloc,
+            low - offset,
+            f"\u2212{agreement:.2f}\u00d7SD",
+            ha="right",
+            va="top",
+            transform=trans,
+        )
         ax.text(xloc, low + offset, "%.2f" % low, ha="right", va="bottom", transform=trans)
 
-    # Add 95% confidence intervals for mean bias and limits of agreement
+    # Confidence intervals for mean bias and limits of agreement
     if confidence is not None:
         assert 0 < confidence < 1
         ci = dict()
         ci["mean"] = stats.t.interval(confidence, dof, loc=mean_diff, scale=mean_diff_se)
         ci["high"] = stats.t.interval(confidence, dof, loc=high, scale=high_low_se)
         ci["low"] = stats.t.interval(confidence, dof, loc=low, scale=high_low_se)
-        ax.axhspan(ci["mean"][0], ci["mean"][1], facecolor="tab:grey", alpha=0.2)
-        ax.axhspan(ci["high"][0], ci["high"][1], facecolor=_scatter_kwargs["color"], alpha=0.2)
-        ax.axhspan(ci["low"][0], ci["low"][1], facecolor=_scatter_kwargs["color"], alpha=0.2)
+        # Bias CI in grey, LoA CIs in blue — independent of scatter color
+        ax.axhspan(ci["mean"][0], ci["mean"][1], facecolor="tab:gray", alpha=0.2)
+        ax.axhspan(ci["high"][0], ci["high"][1], facecolor="tab:blue", alpha=0.2)
+        ax.axhspan(ci["low"][0], ci["low"][1], facecolor="tab:blue", alpha=0.2)
 
-    # Labels
-    ax.set_ylabel(f"{xname} - {yname}")
+    # Labels and symmetric y-axis
+    unit = " [%]" if percentage else ""
+    ax.set_ylabel(f"{xname} \u2212 {yname}{unit}")
     ax.set_xlabel(xlabel)
+    bound = max(abs(lim) for lim in ax.get_ylim())
+    ax.set_ylim(-bound, bound)
     return ax
 
 

--- a/src/pingouin/plotting.py
+++ b/src/pingouin/plotting.py
@@ -142,6 +142,11 @@ def plot_blandaltman(
     # Calculate differences — absolute or percentage
     mean_xy = np.vstack((x, y)).mean(0)
     if percentage:
+        if np.any(mean_xy == 0):
+            raise ValueError(
+                "Percentage differences are undefined when the mean of `x` and `y` "
+                "is zero for one or more paired observations."
+            )
         diff = (x - y) / mean_xy * 100
     else:
         diff = x - y
@@ -272,9 +277,9 @@ def qqplot(
     sparams : tuple, optional
         Distribution-specific shape parameters (shape parameters, location,
         and scale). See :py:func:`scipy.stats.probplot` for more details.
-    confidence : float
+    confidence : float or bool
         Confidence level (.95 = 95%) for point-wise confidence envelope.
-        Can be disabled by passing False.
+        Pass False to disable the confidence envelope.
     square : bool
         If True (default), ensure equal aspect ratio between X and Y axes.
     line_kwargs : dict or None
@@ -508,16 +513,16 @@ def plot_paired(
         .. versionadded:: 0.3.9
     ax : matplotlib axes
         Axis on which to draw the plot.
-    colors : list of str
-        Line colors names. Default is green when value increases from A to B,
-        indianred when value decreases from A to B and grey when the value is
-        the same in both measurements.
-    pointplot_kwargs : dict
-        Dictionnary of optional arguments that are passed to the
-        :py:func:`seaborn.pointplot` function.
-    boxplot_kwargs : dict
-        Dictionnary of optional arguments that are passed to the
-        :py:func:`seaborn.boxplot` function.
+    colors : list of str or None
+        Line colors names. Default (None) uses green when value increases from
+        A to B, indianred when value decreases from A to B, and grey when the
+        value is the same in both measurements.
+    pointplot_kwargs : dict or None
+        Optional keyword arguments passed to :py:func:`seaborn.pointplot`.
+        When None, internal defaults are used.
+    boxplot_kwargs : dict or None
+        Optional keyword arguments passed to :py:func:`seaborn.boxplot`.
+        When None, internal defaults are used.
 
     Returns
     -------
@@ -750,12 +755,15 @@ def plot_rm_corr(
     legend : boolean
         If True, add legend to plot. Legend will show all the unique values in
         ``subject``.
-    kwargs_facetgrid : dict
-        Optional keyword arguments passed to :py:class:`seaborn.FacetGrid`
-    kwargs_line : dict
-        Optional keyword arguments passed to :py:class:`matplotlib.pyplot.plot`
-    kwargs_scatter : dict
-        Optional keyword arguments passed to :py:class:`matplotlib.pyplot.scatter`
+    kwargs_facetgrid : dict or None
+        Optional keyword arguments passed to :py:class:`seaborn.FacetGrid`.
+        When None, internal defaults are used.
+    kwargs_line : dict or None
+        Optional keyword arguments passed to :py:class:`matplotlib.pyplot.plot`.
+        When None, internal defaults are used.
+    kwargs_scatter : dict or None
+        Optional keyword arguments passed to :py:class:`matplotlib.pyplot.scatter`.
+        When None, internal defaults are used.
 
     Returns
     -------
@@ -944,6 +952,10 @@ def plot_circmean(
     angles = np.asarray(angles)
     assert angles.ndim == 1, "angles must be a one-dimensional array."
     assert angles.size > 1, "angles must have at least 2 values."
+    if kwargs_markers is not None and not isinstance(kwargs_markers, dict):
+        raise TypeError("`kwargs_markers` must be a dict or None.")
+    if kwargs_arrow is not None and not isinstance(kwargs_arrow, dict):
+        raise TypeError("`kwargs_arrow` must be a dict or None.")
 
     # Merge caller-supplied kwargs over defaults
     _kwargs_markers = {

--- a/src/pingouin/plotting.py
+++ b/src/pingouin/plotting.py
@@ -10,6 +10,9 @@ import matplotlib.transforms as transforms
 import numpy as np
 import pandas as pd
 import seaborn as sns
+from matplotlib.cbook import normalize_kwargs
+from matplotlib.lines import Line2D
+from matplotlib.patches import Patch
 from scipy import stats
 
 # Set default Seaborn preferences (disabled Pingouin >= 0.3.4)
@@ -33,6 +36,7 @@ def plot_blandaltman(
     confidence=0.95,
     annotate=True,
     percentage=False,
+    symmetric_ylim=False,
     ax=None,
     **kwargs,
 ):
@@ -61,8 +65,20 @@ def plot_blandaltman(
         of agreement values on the right-hand side of the plot.
     percentage : bool
         If True, plot percentage differences relative to the mean of each
-        pair, i.e. ``(x - y) / mean(x, y) * 100``. Useful when measurement
-        variability scales with magnitude. Default is False.
+        pair, i.e. ``(x - y) / abs(mean(x, y)) * 100``. Useful when measurement
+        variability scales with magnitude. This is only meaningful for
+        ratio-scale measurements that stay away from zero: the percentage
+        difference grows without bound as the mean of a pair approaches zero.
+        Default is False.
+
+        .. versionadded:: 0.6.2
+    symmetric_ylim : bool
+        If True, force the y-axis to be symmetric around zero. This avoids
+        conveying a visual bias when the mean difference is close to zero, but
+        compresses the data into a narrow band when the bias is large relative
+        to the spread of the differences. Default is False.
+
+        .. versionadded:: 0.6.2
     ax : matplotlib axes
         Axis on which to draw the plot.
     **kwargs : optional
@@ -147,7 +163,9 @@ def plot_blandaltman(
                 "Percentage differences are undefined when the mean of `x` and `y` "
                 "is zero for one or more paired observations."
             )
-        diff = (x - y) / mean_xy * 100
+        # Divide by the absolute mean, otherwise the sign of the difference would be
+        # flipped for pairs with a negative mean.
+        diff = (x - y) / np.abs(mean_xy) * 100
     else:
         diff = x - y
 
@@ -223,12 +241,13 @@ def plot_blandaltman(
         ax.axhspan(ci["high"][0], ci["high"][1], facecolor="tab:blue", alpha=0.2)
         ax.axhspan(ci["low"][0], ci["low"][1], facecolor="tab:blue", alpha=0.2)
 
-    # Labels and symmetric y-axis
+    # Labels and (optional) symmetric y-axis
     unit = " [%]" if percentage else ""
     ax.set_ylabel(f"{xname} \u2212 {yname}{unit}")
     ax.set_xlabel(xlabel)
-    bound = max(abs(lim) for lim in ax.get_ylim())
-    ax.set_ylim(-bound, bound)
+    if symmetric_ylim:
+        bound = max(abs(lim) for lim in ax.get_ylim())
+        ax.set_ylim(-bound, bound)
     return ax
 
 
@@ -285,10 +304,16 @@ def qqplot(
     line_kwargs : dict or None
         Optional keyword arguments passed to :py:func:`matplotlib.pyplot.plot`
         for the regression line. Default style is ``{"color": "r", "lw": 2}``.
+        Matplotlib aliases and their canonical names (e.g. ``lw`` and
+        ``linewidth``) are interchangeable.
+
+        .. versionadded:: 0.6.2
     ci_kwargs : dict or None
         Optional keyword arguments passed to :py:func:`matplotlib.pyplot.plot`
         for the confidence envelope lines. Default style is
         ``{"color": "r", "ls": "--", "lw": 1.25}``.
+
+        .. versionadded:: 0.6.2
     ax : matplotlib axes
         Axis on which to draw the plot.
     **kwargs : optional
@@ -386,16 +411,21 @@ def qqplot(
     # Update default kwargs with specified inputs
     _scatter_kwargs = {"marker": "o", "color": "blue"}
     _scatter_kwargs.update(kwargs)
-    _line_kwargs = {"color": "r", "lw": 2}
-    _line_kwargs.update(line_kwargs or {})
-    _ci_kwargs = {"color": "r", "ls": "--", "lw": 1.25}
-    _ci_kwargs.update(ci_kwargs or {})
+    # Canonicalize Matplotlib aliases before merging (e.g. "ls" -> "linestyle"), otherwise
+    # a caller passing the long form would collide with the alias used in the defaults.
+    _line_kwargs = normalize_kwargs({"color": "r", "lw": 2}, Line2D)
+    _line_kwargs.update(normalize_kwargs(line_kwargs or {}, Line2D))
+    _ci_kwargs = normalize_kwargs({"color": "r", "ls": "--", "lw": 1.25}, Line2D)
+    _ci_kwargs.update(normalize_kwargs(ci_kwargs or {}, Line2D))
 
     if isinstance(dist, str):
         dist = getattr(stats, dist)
 
     x = np.asarray(x)
     x = x[~np.isnan(x)]  # NaN are automatically removed
+    if x.size > 0 and np.ptp(x) == 0:
+        # A degenerate fit (scale = 0) would divide by zero when standardizing below
+        raise ValueError("All values in `x` are identical: a Q-Q plot requires some variance.")
 
     # Check sparams: if single parameter, tuple becomes int
     if not isinstance(sparams, (tuple, list)):
@@ -417,8 +447,8 @@ def qqplot(
     shape = fit_params[:-2] if len(fit_params) > 2 else None
 
     # Observed values to observed quantiles
-    if loc != 0 or scale != 1:  # pragma: no branch
-        observed = (np.sort(observed) - fit_params[-2]) / fit_params[-1]
+    if loc != 0 or scale != 1:
+        observed = (np.sort(observed) - loc) / scale
 
     # Linear regression
     slope, intercept, r, _, _ = stats.linregress(theor, observed)
@@ -705,10 +735,15 @@ def plot_paired(
         # Set boxplot x and y depending on orientation
         _xbp = within if orient == "v" else dv
         _ybp = dv if orient == "v" else within
+        # Keep track of the patches already present, e.g. on a user-supplied axis, so that
+        # only the ones created by the boxplot below are made transparent.
+        pre_existing = {id(patch) for patch in ax.patches}
         sns.boxplot(data=data, x=_xbp, y=_ybp, order=order, ax=ax, orient=orient, **_boxplot_kwargs)
 
         # Set alpha to patch of boxplot but not to whiskers
         for patch in ax.patches:
+            if id(patch) in pre_existing:
+                continue
             r, g, b, a = patch.get_facecolor()
             patch.set_facecolor((r, g, b, 0.75))
     else:
@@ -898,14 +933,18 @@ def plot_circmean(
         If True (default), ensure equal aspect ratio between X and Y axes.
     ax : matplotlib axes
         Axis on which to draw the plot.
-    kwargs_markers : dict
+    kwargs_markers : dict or None
         Optional keywords arguments that are passed to
         :obj:`matplotlib.axes.Axes.plot`
-        to control the markers aesthetics.
-    kwargs_arrow : dict
+        to control the markers aesthetics. When None, internal defaults are
+        used. Matplotlib aliases and their canonical names (e.g. ``ms`` and
+        ``markersize``) are interchangeable.
+    kwargs_arrow : dict or None
         Optional keywords arguments that are passed to
         :obj:`matplotlib.axes.Axes.arrow`
-        to control the arrow aesthetics.
+        to control the arrow aesthetics. When None, internal defaults are
+        used. Matplotlib aliases and their canonical names (e.g. ``fc`` and
+        ``facecolor``) are interchangeable.
 
     Returns
     -------
@@ -957,22 +996,17 @@ def plot_circmean(
     if kwargs_arrow is not None and not isinstance(kwargs_arrow, dict):
         raise TypeError("`kwargs_arrow` must be a dict or None.")
 
-    # Merge caller-supplied kwargs over defaults
-    _kwargs_markers = {
-        "color": "tab:blue",
-        "marker": "o",
-        "mfc": "none",
-        "ms": 10,
-        **(kwargs_markers or {}),
-    }
-    _kwargs_arrow = {
-        "width": 0.01,
-        "head_width": 0.1,
-        "head_length": 0.1,
-        "fc": "tab:red",
-        "ec": "tab:red",
-        **(kwargs_arrow or {}),
-    }
+    # Merge caller-supplied kwargs over defaults. Matplotlib aliases are canonicalized
+    # first (e.g. "ms" -> "markersize") so that either form overrides the defaults.
+    _kwargs_markers = normalize_kwargs(
+        {"color": "tab:blue", "marker": "o", "mfc": "none", "ms": 10}, Line2D
+    )
+    _kwargs_markers.update(normalize_kwargs(kwargs_markers or {}, Line2D))
+    _kwargs_arrow = normalize_kwargs(
+        {"width": 0.01, "head_width": 0.1, "head_length": 0.1, "fc": "tab:red", "ec": "tab:red"},
+        Patch,
+    )
+    _kwargs_arrow.update(normalize_kwargs(kwargs_arrow or {}, Patch))
 
     # Convert angles to unit vector
     z = np.exp(1j * angles)

--- a/src/pingouin/plotting.py
+++ b/src/pingouin/plotting.py
@@ -412,7 +412,7 @@ def qqplot(
     shape = fit_params[:-2] if len(fit_params) > 2 else None
 
     # Observed values to observed quantiles
-    if loc != 0 or scale != 1:
+    if loc != 0 or scale != 1:  # pragma: no branch
         observed = (np.sort(observed) - fit_params[-2]) / fit_params[-1]
 
     # Linear regression

--- a/src/pingouin/plotting.py
+++ b/src/pingouin/plotting.py
@@ -227,18 +227,16 @@ def plot_blandaltman(
     return ax
 
 
-def _ppoints(n, a=0.5):
+def _ppoints(n):
     """
     Ordinates For Probability Plotting.
 
-    Numpy analogue or `R`'s `ppoints` function.
+    Numpy analogue of `R`'s `ppoints` function.
 
     Parameters
     ----------
     n : int
-        Number of points generated
-    a : float
-        Offset fraction (typically between 0 and 1)
+        Number of points generated.
 
     Returns
     -------
@@ -246,11 +244,22 @@ def _ppoints(n, a=0.5):
         Sequence of probabilities at which to evaluate the inverse
         distribution.
     """
+    # Use a = 3/8 for small samples (n <= 10), 0.5 otherwise (Blom, 1958)
     a = 3 / 8 if n <= 10 else 0.5
     return (np.arange(n) + 1 - a) / (n + 1 - 2 * a)
 
 
-def qqplot(x, dist="norm", sparams=(), confidence=0.95, square=True, ax=None, **kwargs):
+def qqplot(
+    x,
+    dist="norm",
+    sparams=(),
+    confidence=0.95,
+    square=True,
+    line_kwargs=None,
+    ci_kwargs=None,
+    ax=None,
+    **kwargs,
+):
     """Quantile-Quantile plot.
 
     Parameters
@@ -266,10 +275,17 @@ def qqplot(x, dist="norm", sparams=(), confidence=0.95, square=True, ax=None, **
     confidence : float
         Confidence level (.95 = 95%) for point-wise confidence envelope.
         Can be disabled by passing False.
-    square: bool
+    square : bool
         If True (default), ensure equal aspect ratio between X and Y axes.
+    line_kwargs : dict or None
+        Optional keyword arguments passed to :py:func:`matplotlib.pyplot.plot`
+        for the regression line. Default style is ``{"color": "r", "lw": 2}``.
+    ci_kwargs : dict or None
+        Optional keyword arguments passed to :py:func:`matplotlib.pyplot.plot`
+        for the confidence envelope lines. Default style is
+        ``{"color": "r", "ls": "--", "lw": 1.25}``.
     ax : matplotlib axes
-        Axis on which to draw the plot
+        Axis on which to draw the plot.
     **kwargs : optional
         Optional argument(s) passed to :py:func:`matplotlib.pyplot.scatter`.
 
@@ -365,6 +381,10 @@ def qqplot(x, dist="norm", sparams=(), confidence=0.95, square=True, ax=None, **
     # Update default kwargs with specified inputs
     _scatter_kwargs = {"marker": "o", "color": "blue"}
     _scatter_kwargs.update(kwargs)
+    _line_kwargs = {"color": "r", "lw": 2}
+    _line_kwargs.update(line_kwargs or {})
+    _ci_kwargs = {"color": "r", "ls": "--", "lw": 1.25}
+    _ci_kwargs.update(ci_kwargs or {})
 
     if isinstance(dist, str):
         dist = getattr(stats, dist)
@@ -392,7 +412,7 @@ def qqplot(x, dist="norm", sparams=(), confidence=0.95, square=True, ax=None, **
     shape = fit_params[:-2] if len(fit_params) > 2 else None
 
     # Observed values to observed quantiles
-    if loc != 0 and scale != 1:
+    if loc != 0 or scale != 1:
         observed = (np.sort(observed) - fit_params[-2]) / fit_params[-1]
 
     # Linear regression
@@ -417,7 +437,7 @@ def qqplot(x, dist="norm", sparams=(), confidence=0.95, square=True, ax=None, **
 
     # Add regression line and annotate R2
     fit_val = slope * theor + intercept
-    ax.plot(theor, fit_val, "r-", lw=2)
+    ax.plot(theor, fit_val, **_line_kwargs)
     posx = end_pts[0] + 0.60 * (end_pts[1] - end_pts[0])
     posy = end_pts[0] + 0.10 * (end_pts[1] - end_pts[0])
     ax.text(posx, posy, "$R^2=%.3f$" % r**2)
@@ -431,8 +451,8 @@ def qqplot(x, dist="norm", sparams=(), confidence=0.95, square=True, ax=None, **
         se = (slope / pdf) * np.sqrt(P * (1 - P) / n)
         upper = fit_val + crit * se
         lower = fit_val - crit * se
-        ax.plot(theor, upper, "r--", lw=1.25)
-        ax.plot(theor, lower, "r--", lw=1.25)
+        ax.plot(theor, upper, **_ci_kwargs)
+        ax.plot(theor, lower, **_ci_kwargs)
 
     # Make square
     if square:
@@ -451,9 +471,9 @@ def plot_paired(
     boxplot_in_front=False,
     orient="v",
     ax=None,
-    colors=["green", "grey", "indianred"],
-    pointplot_kwargs={"scale": 0.6, "marker": "."},
-    boxplot_kwargs={"color": "lightslategrey", "width": 0.2},
+    colors=None,
+    pointplot_kwargs=None,
+    boxplot_kwargs=None,
 ):
     """
     Paired plot.
@@ -564,11 +584,13 @@ def plot_paired(
     """
     from pingouin.utils import _check_dataframe
 
+    if colors is None:
+        colors = ["green", "grey", "indianred"]
     # Update default kwargs with specified inputs
     _pointplot_kwargs = {"scale": 0.6, "marker": "."}
-    _pointplot_kwargs.update(pointplot_kwargs)
+    _pointplot_kwargs.update(pointplot_kwargs or {})
     _boxplot_kwargs = {"color": "lightslategrey", "width": 0.2}
-    _boxplot_kwargs.update(boxplot_kwargs)
+    _boxplot_kwargs.update(boxplot_kwargs or {})
     # Extract pointplot alpha, if set
     pp_alpha = _pointplot_kwargs.pop("alpha", 1.0)
 
@@ -614,9 +636,10 @@ def plot_paired(
     if order is None:
         order = x_cat
     else:
-        assert len(order) == len(x_cat), (
-            "Order must have the same number of elements as the number of levels in `within`."
-        )
+        if len(order) != len(x_cat):
+            raise ValueError(
+                "Order must have the same number of elements as the number of levels in `within`."
+            )
 
     # Substitue within by integer order of the ordered columns to allow for
     # changing the order of numeric withins.
@@ -680,7 +703,7 @@ def plot_paired(
         sns.boxplot(data=data, x=_xbp, y=_ybp, order=order, ax=ax, orient=orient, **_boxplot_kwargs)
 
         # Set alpha to patch of boxplot but not to whiskers
-        for patch in ax.artists:
+        for patch in ax.patches:
             r, g, b, a = patch.get_facecolor()
             patch.set_facecolor((r, g, b, 0.75))
     else:
@@ -710,9 +733,9 @@ def plot_rm_corr(
     y=None,
     subject=None,
     legend=False,
-    kwargs_facetgrid=dict(height=4, aspect=1),
-    kwargs_line=dict(ls="solid"),
-    kwargs_scatter=dict(marker="o"),
+    kwargs_facetgrid=None,
+    kwargs_line=None,
+    kwargs_scatter=None,
 ):
     """Plot a repeated measures correlation.
 
@@ -789,6 +812,13 @@ def plot_rm_corr(
         ...     kwargs_facetgrid=dict(height=4.5, aspect=1.5, palette="Spectral"),
         ... )
     """
+    _kwargs_facetgrid = {"height": 4, "aspect": 1}
+    _kwargs_facetgrid.update(kwargs_facetgrid or {})
+    _kwargs_line = {"ls": "solid"}
+    _kwargs_line.update(kwargs_line or {})
+    _kwargs_scatter = {"marker": "o"}
+    _kwargs_scatter.update(kwargs_scatter or {})
+
     # Check that stasmodels is installed
     from pingouin.utils import _is_statsmodels_installed
 
@@ -826,13 +856,13 @@ def plot_rm_corr(
     data["pred"] = model.fittedvalues
 
     # Define color palette
-    if "palette" not in kwargs_facetgrid:
-        kwargs_facetgrid["palette"] = sns.hls_palette(data[subject].nunique())
+    if "palette" not in _kwargs_facetgrid:
+        _kwargs_facetgrid["palette"] = sns.hls_palette(data[subject].nunique())
 
     # Start plot
-    g = sns.FacetGrid(data, hue=subject, **kwargs_facetgrid)
-    g = g.map(sns.regplot, x, "pred", scatter=False, ci=None, truncate=True, line_kws=kwargs_line)
-    g = g.map(sns.scatterplot, x, y, **kwargs_scatter)
+    g = sns.FacetGrid(data, hue=subject, **_kwargs_facetgrid)
+    g = g.map(sns.regplot, x, "pred", scatter=False, ci=None, truncate=True, line_kws=_kwargs_line)
+    g = g.map(sns.scatterplot, x, y, **_kwargs_scatter)
 
     if legend:
         g.add_legend()
@@ -844,8 +874,8 @@ def plot_circmean(
     angles,
     square=True,
     ax=None,
-    kwargs_markers=dict(color="tab:blue", marker="o", mfc="none", ms=10),
-    kwargs_arrow=dict(width=0.01, head_width=0.1, head_length=0.1, fc="tab:red", ec="tab:red"),
+    kwargs_markers=None,
+    kwargs_arrow=None,
 ):
     """Plot the circular mean and vector length of a set of angles
     on the unit circle.
@@ -915,29 +945,22 @@ def plot_circmean(
     assert angles.ndim == 1, "angles must be a one-dimensional array."
     assert angles.size > 1, "angles must have at least 2 values."
 
-    assert isinstance(kwargs_markers, dict), "kwargs_markers must be a dict."
-    assert isinstance(kwargs_arrow, dict), "kwargs_arrow must be a dict."
-
-    # Fill missing values in dict
-    if "color" not in kwargs_markers.keys():
-        kwargs_markers["color"] = "tab:blue"
-    if "marker" not in kwargs_markers.keys():
-        kwargs_markers["marker"] = "o"
-    if "mfc" not in kwargs_markers.keys():
-        kwargs_markers["mfc"] = "none"
-    if "ms" not in kwargs_markers.keys():
-        kwargs_markers["ms"] = 10
-
-    if "width" not in kwargs_arrow.keys():
-        kwargs_arrow["width"] = 0.01
-    if "head_width" not in kwargs_arrow.keys():
-        kwargs_arrow["head_width"] = 0.1
-    if "head_length" not in kwargs_arrow.keys():
-        kwargs_arrow["head_length"] = 0.1
-    if "fc" not in kwargs_arrow.keys():
-        kwargs_arrow["fc"] = "tab:red"
-    if "ec" not in kwargs_arrow.keys():
-        kwargs_arrow["ec"] = "tab:red"
+    # Merge caller-supplied kwargs over defaults
+    _kwargs_markers = {
+        "color": "tab:blue",
+        "marker": "o",
+        "mfc": "none",
+        "ms": 10,
+        **(kwargs_markers or {}),
+    }
+    _kwargs_arrow = {
+        "width": 0.01,
+        "head_width": 0.1,
+        "head_length": 0.1,
+        "fc": "tab:red",
+        "ec": "tab:red",
+        **(kwargs_arrow or {}),
+    }
 
     # Convert angles to unit vector
     z = np.exp(1j * angles)
@@ -952,10 +975,10 @@ def plot_circmean(
     ax.add_patch(circle)
     ax.axvline(0, lw=1, ls=":", color="slategrey")
     ax.axhline(0, lw=1, ls=":", color="slategrey")
-    ax.plot(np.real(z), np.imag(z), ls="None", **kwargs_markers)
+    ax.plot(np.real(z), np.imag(z), ls="None", **_kwargs_markers)
 
     # Plot mean resultant vector
-    ax.arrow(0, 0, np.real(zm), np.imag(zm), **kwargs_arrow)
+    ax.arrow(0, 0, np.real(zm), np.imag(zm), **_kwargs_arrow)
 
     # X and Y ticks in radians
     ax.set_xticks([])

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -201,6 +201,11 @@ class TestPlotting(TestCase):
         assert isinstance(ax, matplotlib.axes.Axes)
         ax = plot_circmean(angles, kwargs_markers={}, kwargs_arrow={})
         assert isinstance(ax, matplotlib.axes.Axes)
+        # Non-dict kwargs raise TypeError
+        with pytest.raises(TypeError):
+            plot_circmean(angles, kwargs_markers="red")
+        with pytest.raises(TypeError):
+            plot_circmean(angles, kwargs_arrow="red")
         # Explicit ax exercises the ax-is-not-None branch; square=False skips set_aspect
         _, ax2 = plt.subplots(1, 1)
         ax = plot_circmean(angles, ax=ax2, square=False)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -90,6 +90,9 @@ class TestPlotting(TestCase):
         # Error: required parameters are not specified
         with pytest.raises(ValueError):
             qqplot(x_ln, dist="lognorm", sparams=())
+        # Custom line and CI kwargs; square=False
+        qqplot(x, line_kwargs={"color": "k", "lw": 1}, ci_kwargs={"color": "k", "ls": ":"})
+        qqplot(x, square=False)
         plt.close("all")
 
     def test_plot_paired(self):
@@ -106,6 +109,23 @@ class TestPlotting(TestCase):
         plot_paired(
             data=df, dv="Scores", within="Time", subject="Subject", order=["June", "August"], ax=ax2
         )
+        # Explicit colors (exercises the colors-is-not-None branch)
+        plot_paired(
+            data=df,
+            dv="Scores",
+            within="Time",
+            subject="Subject",
+            colors=["blue", "grey", "red"],
+        )
+        # Mismatched order length raises ValueError
+        with pytest.raises(ValueError):
+            plot_paired(
+                data=df,
+                dv="Scores",
+                within="Time",
+                subject="Subject",
+                order=["June", "August", "Extra"],
+            )
         plot_paired(
             data=df,
             dv="Scores",
@@ -145,6 +165,26 @@ class TestPlotting(TestCase):
         g = plot_rm_corr(data=df, x="pH", y="PacO2", subject="Subject")
         g = plot_rm_corr(data=df, x="pH", y="PacO2", subject="Subject", legend=False)
         assert isinstance(g, sns.FacetGrid)
+        # legend=True exercises g.add_legend()
+        g = plot_rm_corr(data=df, x="pH", y="PacO2", subject="Subject", legend=True)
+        assert isinstance(g, sns.FacetGrid)
+        # Passing a palette in kwargs_facetgrid exercises the palette-already-set branch
+        g = plot_rm_corr(
+            data=df,
+            x="pH",
+            y="PacO2",
+            subject="Subject",
+            kwargs_facetgrid={"height": 4, "aspect": 1, "palette": "Set2"},
+        )
+        assert isinstance(g, sns.FacetGrid)
+        # Fewer than 3 subjects raises ValueError
+        with pytest.raises(ValueError):
+            plot_rm_corr(
+                data=df.query("Subject in [1, 2]"),
+                x="pH",
+                y="PacO2",
+                subject="Subject",
+            )
         plt.close("all")
 
     def test_plot_circmean(self):
@@ -157,5 +197,9 @@ class TestPlotting(TestCase):
         ax = plot_circmean(angles)
         assert isinstance(ax, matplotlib.axes.Axes)
         ax = plot_circmean(angles, kwargs_markers={}, kwargs_arrow={})
+        assert isinstance(ax, matplotlib.axes.Axes)
+        # Explicit ax exercises the ax-is-not-None branch; square=False skips set_aspect
+        _, ax2 = plt.subplots(1, 1)
+        ax = plot_circmean(angles, ax=ax2, square=False)
         assert isinstance(ax, matplotlib.axes.Axes)
         plt.close("all")

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -46,6 +46,9 @@ class TestPlotting(TestCase):
         plot_blandaltman(x, y, xaxis="y", color="green", s=10)
         plot_blandaltman(x, y, percentage=True)
         plot_blandaltman(x, y, percentage=True, confidence=None, annotate=False)
+        # percentage=True raises ValueError when mean(x, y) == 0 for any pair
+        with pytest.raises(ValueError, match="zero"):
+            plot_blandaltman(np.array([1.0, -1.0]), np.array([-1.0, 1.0]), percentage=True)
         plt.close("all")
 
     def test_ppoints(self):

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -44,6 +44,8 @@ class TestPlotting(TestCase):
         plot_blandaltman(x, y, annotate=False)
         plot_blandaltman(x, y, xaxis="x", confidence=None)
         plot_blandaltman(x, y, xaxis="y", color="green", s=10)
+        plot_blandaltman(x, y, percentage=True)
+        plot_blandaltman(x, y, percentage=True, confidence=None, annotate=False)
         plt.close("all")
 
     def test_ppoints(self):

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -49,6 +49,23 @@ class TestPlotting(TestCase):
         # percentage=True raises ValueError when mean(x, y) == 0 for any pair
         with pytest.raises(ValueError, match="zero"):
             plot_blandaltman(np.array([1.0, -1.0]), np.array([-1.0, 1.0]), percentage=True)
+        # percentage=True must preserve the sign of the difference when the data is negative
+        _, ax3 = plt.subplots()
+        plot_blandaltman(
+            np.array([-10.0, -20.0, -30.0]),
+            np.array([-11.0, -22.0, -33.0]),
+            percentage=True,
+            ax=ax3,
+        )
+        assert (ax3.collections[0].get_offsets()[:, 1] > 0).all()
+        # The y-axis is only symmetric around zero when explicitly requested
+        _, (ax4, ax5) = plt.subplots(1, 2, figsize=(9, 4))
+        plot_blandaltman(x, y, ax=ax4)
+        low, high = ax4.get_ylim()
+        assert abs(low) != pytest.approx(abs(high))
+        plot_blandaltman(x, y, symmetric_ylim=True, ax=ax5)
+        low, high = ax5.get_ylim()
+        assert low == -high
         plt.close("all")
 
     def test_ppoints(self):
@@ -95,7 +112,14 @@ class TestPlotting(TestCase):
             qqplot(x_ln, dist="lognorm", sparams=())
         # Custom line and CI kwargs; square=False
         qqplot(x, line_kwargs={"color": "k", "lw": 1}, ci_kwargs={"color": "k", "ls": ":"})
+        # Canonical Matplotlib names must override the aliases used in the defaults
+        qqplot(x, line_kwargs={"linewidth": 1}, ci_kwargs={"linestyle": ":", "linewidth": 1})
         qqplot(x, square=False)
+        # An exact identity fit (loc = 0, scale = 1) skips the standardization
+        assert isinstance(qqplot(np.array([-1.0, 1.0])), matplotlib.axes.Axes)
+        # Zero-variance input raises ValueError instead of dividing by zero
+        with pytest.raises(ValueError, match="identical"):
+            qqplot(np.zeros(20))
         plt.close("all")
 
     def test_plot_paired(self):
@@ -120,6 +144,12 @@ class TestPlotting(TestCase):
             subject="Subject",
             colors=["blue", "grey", "red"],
         )
+        # Patches already present on a user-supplied axis must not be restyled
+        _, ax3 = plt.subplots()
+        span = ax3.axvspan(-0.5, 0.5, facecolor="orange")
+        facecolor = span.get_facecolor()
+        plot_paired(data=df, dv="Scores", within="Time", subject="Subject", ax=ax3)
+        assert span.get_facecolor() == facecolor
         # Mismatched order length raises ValueError
         with pytest.raises(ValueError):
             plot_paired(
@@ -200,6 +230,11 @@ class TestPlotting(TestCase):
         ax = plot_circmean(angles)
         assert isinstance(ax, matplotlib.axes.Axes)
         ax = plot_circmean(angles, kwargs_markers={}, kwargs_arrow={})
+        assert isinstance(ax, matplotlib.axes.Axes)
+        # Canonical Matplotlib names must override the aliases used in the defaults
+        ax = plot_circmean(
+            angles, kwargs_markers={"markersize": 5}, kwargs_arrow={"facecolor": "k"}
+        )
         assert isinstance(ax, matplotlib.axes.Axes)
         # Non-dict kwargs raise TypeError
         with pytest.raises(TypeError):


### PR DESCRIPTION
This PR improves all plotting functions in `pingouin/plotting.py`. Changes span bug fixes, new parameters, API corrections, and code clarity improvements.

---

## Bug fixes

### `plot_paired`: `ax.artists` replaced with `ax.patches`

The boxplot transparency logic iterated over `ax.artists`. Modern versions of matplotlib no longer register boxplot patches there — `ax.artists` returns an empty list — so the loop silently did nothing and the boxplots were drawn fully opaque. It now iterates over `ax.patches`, and only over the patches created by the `seaborn.boxplot` call itself, so that any artists already present on a user-supplied `ax` are left untouched.

### `qqplot`: normalization condition corrected

The condition that normalizes observed quantiles read:

```python
if loc != 0 and scale != 1:
```

This meant normalization was skipped whenever only one of `loc` or `scale` differed from the identity transform (for example, a fit with `loc=0` but `scale=2.5`). The condition is now:

```python
if loc != 0 or scale != 1:
```

Standardizing now also raises a `ValueError` when `x` has zero variance (all values identical). With the corrected `or` condition, such input would divide by `scale=0` and produce an all-NaN plot.

### Mutable default arguments fixed in `plot_paired`, `plot_rm_corr`, `plot_circmean`

All three functions used mutable objects (`list` or `dict`) as default parameter values. This is a known Python pitfall: if a caller mutated the default object, all subsequent calls would be affected. The defaults are now `None` and the internal defaults are constructed fresh on each call.

**Affected parameters:**

| Function | Parameters |
|---|---|
| `plot_paired` | `colors`, `pointplot_kwargs`, `boxplot_kwargs` |
| `plot_rm_corr` | `kwargs_facetgrid`, `kwargs_line`, `kwargs_scatter` |
| `plot_circmean` | `kwargs_markers`, `kwargs_arrow` |

The default values are unchanged. Existing call sites that pass these arguments explicitly are unaffected.

---

## New functionality

### `plot_blandaltman`: `percentage` parameter

```python
ax = pg.plot_blandaltman(df["A"], df["B"], percentage=True)
```

When `percentage=True`, differences are expressed as `(x - y) / abs(mean(x, y)) * 100`. This is the recommended form of the Bland-Altman plot when measurement variability scales with magnitude or when the two methods use different units/ranges. The y-axis label is updated to include `[%]`.

The denominator uses the *absolute* mean so that the sign of the difference is preserved for negative measurements. A `ValueError` is raised when the mean of a pair is exactly zero; more generally, percentage differences are only meaningful for ratio-scale data that stays away from zero, since they grow without bound as a pair mean approaches zero.

### `qqplot`: `line_kwargs` and `ci_kwargs` parameters

The regression fit line and confidence envelope were previously hardcoded as red (`"r-"` and `"r--"`). Two new optional parameters allow full control over their appearance:

```python
ax = pg.qqplot(
    x,
    line_kwargs={"color": "steelblue", "lw": 1.5},
    ci_kwargs={"color": "steelblue", "ls": ":", "lw": 1},
)
```

Both parameters accept any keyword arguments accepted by `matplotlib.pyplot.plot`. Omitting them reproduces the previous default style.

### `plot_blandaltman`: `symmetric_ylim` parameter

```python
ax = pg.plot_blandaltman(df["A"], df["B"], symmetric_ylim=True)
```

Forces the y-axis to be symmetric around zero, which avoids conveying a visual bias when the mean difference is close to zero. Opt-in (default `False`), because forcing symmetry inflates the axis and compresses the data into a narrow band whenever the bias is large relative to the spread of the differences. The default y-limits are unchanged from v0.6.1.

---

## Visual improvements to `plot_blandaltman`

### Zero reference line

A light grey horizontal line is drawn at `y = 0` (perfect agreement) behind all other plot elements. This is a standard component of Bland-Altman plots that was previously missing.

### Corrected annotation labels

The upper and lower limits of agreement (LoA) labels previously read `"+1.96 SD"`, which is only accurate when `agreement=1.96`. The labels now read `+{agreement:.2f}×SD` and `−{agreement:.2f}×SD` and are accurate for any value of `agreement`.

### Decoupled CI band colors

The confidence interval bands for the limits of agreement previously inherited the scatter point color. This meant that setting `color="tab:red"` would also change the LoA CI bands to red. The colors are now independent:

- Bias (mean difference) CI band: `tab:gray`
- LoA CI bands: `tab:blue`

### Limits of agreement line style

The LoA lines are now drawn with `linestyle="--"` (dashed) instead of `linestyle=":"` (dotted), which is the more common convention and improves legibility at small figure sizes.

---

## Code clarity

### `plot_circmean`: simplified default-merging

The 10-line block of `if "key" not in dict` checks has been replaced with a single merge that also canonicalizes matplotlib aliases, so `kwargs_markers={"markersize": 5}` overrides the default `ms` instead of raising a `TypeError` about colliding aliases:

```python
_kwargs_markers = normalize_kwargs(
    {"color": "tab:blue", "marker": "o", "mfc": "none", "ms": 10}, Line2D
)
_kwargs_markers.update(normalize_kwargs(kwargs_markers or {}, Line2D))
```

### `_ppoints`: added formula comment

A short comment now links the `a` constant to Blom (1958), the original source for the two values (`3/8` for small samples, `0.5` otherwise).

### `plot_blandaltman`: SE formula comment

A comment on the LoA standard error formula now cites the original Bland and Altman (1986) paper, making the non-obvious `sqrt(3 * s² / n)` expression self-documenting.

----

## Breaking changes

Argument validation now raises specific exception types instead of `AssertionError`. Callers catching `AssertionError` will need to update:

| Function | Check | Before | After |
|---|---|---|---|
| `plot_paired` | `order` length vs. number of `within` levels | `AssertionError` | `ValueError` |
| `plot_circmean` | `kwargs_markers` / `kwargs_arrow` is not a dict | `AssertionError` | `TypeError` |

In addition, `qqplot` now raises `ValueError` for zero-variance input, which previously produced a degenerate plot.