### PR TITLE
compute_effsize: honor eftype for one-sample tests (eta_square was out of range)

### DIFF
--- a/src/pingouin/effsize.py
+++ b/src/pingouin/effsize.py
@@ -802,7 +802,7 @@ def compute_effsize(x, y, paired=False, eftype="cohen"):
     if ny == 1:
         # Case 1: One-sample Test
         d = (x.mean() - y) / x.std(ddof=1)
-        return d
+        return convert_effsize(d, "cohen", eftype, nx=nx, ny=ny)
     if eftype.lower() == "r":
         # Return correlation coefficient (useful for CI bootstrapping)
         r, _ = pearsonr(x, y)

--- a/tests/test_effsize.py
+++ b/tests/test_effsize.py
@@ -240,6 +240,21 @@ class TestEffsize(TestCase):
         with pytest.raises(ValueError):
             cef(d, "AUC", "eta_square")
 
+    def test_compute_effsize_one_sample_eftype(self):
+        """One-sample effect sizes must honor eftype, not always return Cohen d."""
+        from pingouin.effsize import convert_effsize
+
+        xs = [1, 2, 3, 4, 5, 6, 7]
+        d = compute_effsize(xs, y=0, eftype="cohen")
+        # eta-squared is bounded in [0, 1] by definition; the one-sample path
+        # used to return the raw Cohen d (1.85), which is out of range.
+        eta = compute_effsize(xs, y=0, eftype="eta_square")
+        assert 0 <= eta <= 1
+        # other types must match convert_effsize applied to the one-sample d
+        for eftype in ["hedges", "odds_ratio", "eta_square"]:
+            expected = convert_effsize(d, "cohen", eftype, nx=len(xs), ny=1)
+            assert np.isclose(compute_effsize(xs, y=0, eftype=eftype), expected)
+
     def test_compute_effsize(self):
         """Test function compute_effsize"""
         compute_effsize(x=x, y=y, eftype="cohen", paired=False)


### PR DESCRIPTION
For a one-sample test (scalar `y`), `compute_effsize` ignores the `eftype` argument and always returns the raw Cohen's d. In particular `eftype="eta_square"` returns a value greater than 1, which is impossible since eta-squared is bounded in `[0, 1]`.

```python
import pingouin as pg
x = [1, 2, 3, 4, 5, 6, 7]
pg.compute_effsize(x, y=0, eftype="eta_square")  # 1.85  (must be <= 1)
pg.compute_effsize(x, y=0, eftype="hedges")      # 1.85  (should be 1.61)
pg.compute_effsize(x, y=0, eftype="odds_ratio")  # 1.85  (should be 28.75)
```

The two-sample branch already converts Cohen's d to the requested effect size via `convert_effsize`; the one-sample branch returned `d` directly and skipped that step. This routes the one-sample d through the same `convert_effsize` call, so `eftype` is honored: eta_square 0.462, hedges 1.610, odds_ratio 28.75, and `cohen` is unchanged. Added a regression test. Happy to add a changelog entry if you'd like.
